### PR TITLE
feat #8: 音声UI（React）+ POS連携フロントエンド

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,654 @@
+/* ============================================
+   POS Voice Concierge — Responsive Styles
+   タブレット端末（POS端末想定）での操作性を重視
+   ============================================ */
+
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+	margin: 0;
+	padding: 0;
+}
+
+:root {
+	--color-primary: #2563eb;
+	--color-primary-dark: #1d4ed8;
+	--color-primary-light: #dbeafe;
+	--color-danger: #dc2626;
+	--color-danger-light: #fef2f2;
+	--color-success: #16a34a;
+	--color-success-light: #f0fdf4;
+	--color-warning: #ca8a04;
+	--color-warning-light: #fefce8;
+	--color-gray-50: #f9fafb;
+	--color-gray-100: #f3f4f6;
+	--color-gray-200: #e5e7eb;
+	--color-gray-300: #d1d5db;
+	--color-gray-500: #6b7280;
+	--color-gray-700: #374151;
+	--color-gray-900: #111827;
+	--radius-sm: 6px;
+	--radius-md: 10px;
+	--radius-lg: 16px;
+	--radius-full: 9999px;
+	--shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+	--shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+	--shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+	--font-size-sm: 0.875rem;
+	--font-size-base: 1rem;
+	--font-size-lg: 1.125rem;
+	--font-size-xl: 1.25rem;
+	--font-size-2xl: 1.5rem;
+	--spacing-xs: 0.25rem;
+	--spacing-sm: 0.5rem;
+	--spacing-md: 1rem;
+	--spacing-lg: 1.5rem;
+	--spacing-xl: 2rem;
+	--spacing-2xl: 3rem;
+}
+
+body {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans JP",
+		sans-serif;
+	background: var(--color-gray-50);
+	color: var(--color-gray-900);
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+/* === App Layout === */
+.pos-voice-concierge {
+	max-width: 800px;
+	margin: 0 auto;
+	padding: var(--spacing-lg);
+	min-height: 100dvh;
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-lg);
+}
+
+.pos-voice-concierge__header {
+	text-align: center;
+	padding: var(--spacing-md) 0;
+}
+
+.pos-voice-concierge__title {
+	font-size: var(--font-size-2xl);
+	font-weight: 700;
+	color: var(--color-gray-900);
+}
+
+.pos-voice-concierge__controls {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: var(--spacing-md);
+}
+
+.pos-voice-concierge__tts-status {
+	font-size: var(--font-size-sm);
+	color: var(--color-primary);
+	display: flex;
+	align-items: center;
+	gap: var(--spacing-xs);
+}
+
+/* === Error Display === */
+.error-display {
+	background: var(--color-danger-light);
+	border: 1px solid var(--color-danger);
+	border-radius: var(--radius-md);
+	padding: var(--spacing-md);
+	color: var(--color-danger);
+	font-size: var(--font-size-base);
+}
+
+/* === Mic Button === */
+.mic-button {
+	display: inline-flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: var(--spacing-sm);
+	width: 120px;
+	height: 120px;
+	border-radius: var(--radius-full);
+	border: 3px solid var(--color-primary);
+	background: white;
+	color: var(--color-primary);
+	cursor: pointer;
+	font-size: var(--font-size-base);
+	font-weight: 600;
+	position: relative;
+	transition: background-color 0.2s, border-color 0.2s, transform 0.1s;
+	-webkit-tap-highlight-color: transparent;
+	touch-action: manipulation;
+}
+
+.mic-button:hover:not(:disabled) {
+	background: var(--color-primary-light);
+}
+
+.mic-button:active:not(:disabled) {
+	transform: scale(0.95);
+}
+
+.mic-button:disabled {
+	cursor: not-allowed;
+	opacity: 0.7;
+}
+
+.mic-button--listening {
+	background: var(--color-danger);
+	border-color: var(--color-danger);
+	color: white;
+}
+
+.mic-button--listening:hover:not(:disabled) {
+	background: #b91c1c;
+}
+
+.mic-button--processing {
+	border-color: var(--color-warning);
+	color: var(--color-warning);
+}
+
+.mic-button--error {
+	border-color: var(--color-danger);
+	color: var(--color-danger);
+}
+
+.mic-button__icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.mic-button__text {
+	font-size: var(--font-size-sm);
+}
+
+.mic-button__pulse {
+	position: absolute;
+	inset: -8px;
+	border-radius: var(--radius-full);
+	border: 2px solid var(--color-danger);
+	animation: pulse 1.5s ease-in-out infinite;
+}
+
+.mic-button__spinner {
+	display: inline-block;
+	width: 24px;
+	height: 24px;
+	border: 3px solid var(--color-gray-200);
+	border-top-color: var(--color-warning);
+	border-radius: var(--radius-full);
+	animation: spin 0.8s linear infinite;
+}
+
+@keyframes pulse {
+	0% {
+		opacity: 1;
+		transform: scale(1);
+	}
+	100% {
+		opacity: 0;
+		transform: scale(1.4);
+	}
+}
+
+@keyframes spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+/* === Transcript Display === */
+.transcript-display {
+	background: white;
+	border-radius: var(--radius-lg);
+	padding: var(--spacing-lg);
+	box-shadow: var(--shadow-md);
+}
+
+.transcript-display__heading {
+	font-size: var(--font-size-lg);
+	font-weight: 600;
+	margin-bottom: var(--spacing-md);
+	color: var(--color-gray-700);
+}
+
+.transcript-display__text {
+	font-size: var(--font-size-xl);
+	font-weight: 500;
+	line-height: 1.5;
+	padding: var(--spacing-sm) 0;
+}
+
+.transcript-display__text--interim {
+	color: var(--color-gray-500);
+	font-style: italic;
+}
+
+.transcript-display__confidence {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing-sm);
+	margin-top: var(--spacing-sm);
+	font-size: var(--font-size-sm);
+	color: var(--color-gray-500);
+}
+
+.transcript-display__confidence-bar {
+	flex: 1;
+	max-width: 200px;
+	height: 6px;
+	background: var(--color-gray-200);
+	border-radius: var(--radius-full);
+	overflow: hidden;
+}
+
+.transcript-display__confidence-fill {
+	height: 100%;
+	background: var(--color-success);
+	border-radius: var(--radius-full);
+	transition: width 0.3s ease;
+}
+
+.transcript-display__interim-label {
+	font-size: var(--font-size-sm);
+	color: var(--color-primary);
+	margin-top: var(--spacing-sm);
+	animation: blink 1.5s ease-in-out infinite;
+}
+
+@keyframes blink {
+	50% {
+		opacity: 0.5;
+	}
+}
+
+/* === Match List === */
+.match-list {
+	background: white;
+	border-radius: var(--radius-lg);
+	padding: var(--spacing-lg);
+	box-shadow: var(--shadow-md);
+}
+
+.match-list--empty {
+	text-align: center;
+	color: var(--color-gray-500);
+}
+
+.match-list__heading {
+	font-size: var(--font-size-lg);
+	font-weight: 600;
+	margin-bottom: var(--spacing-md);
+	color: var(--color-gray-700);
+}
+
+.match-list__items {
+	list-style: none;
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-sm);
+}
+
+.match-list__item {
+	border-radius: var(--radius-md);
+	transition: background-color 0.15s;
+}
+
+.match-list__item--selected {
+	background: var(--color-success-light);
+	outline: 2px solid var(--color-success);
+	outline-offset: -2px;
+}
+
+.match-list__button {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	width: 100%;
+	padding: var(--spacing-md);
+	border: 1px solid var(--color-gray-200);
+	border-radius: var(--radius-md);
+	background: transparent;
+	cursor: pointer;
+	font-size: var(--font-size-base);
+	text-align: left;
+	transition: border-color 0.15s, background-color 0.15s;
+	-webkit-tap-highlight-color: transparent;
+	touch-action: manipulation;
+}
+
+.match-list__button:hover {
+	border-color: var(--color-primary);
+	background: var(--color-primary-light);
+}
+
+.match-list__button:active {
+	background: var(--color-primary);
+	color: white;
+}
+
+.match-list__product-name {
+	font-weight: 500;
+	flex: 1;
+}
+
+.match-list__details {
+	display: flex;
+	gap: var(--spacing-md);
+	font-size: var(--font-size-sm);
+	color: var(--color-gray-500);
+}
+
+.match-list__correct-button {
+	margin-top: var(--spacing-md);
+	display: block;
+	width: 100%;
+	padding: var(--spacing-sm) var(--spacing-md);
+	border: 1px dashed var(--color-gray-300);
+	border-radius: var(--radius-md);
+	background: transparent;
+	cursor: pointer;
+	font-size: var(--font-size-sm);
+	color: var(--color-gray-500);
+	text-align: center;
+	transition: all 0.15s;
+}
+
+.match-list__correct-button:hover {
+	border-color: var(--color-primary);
+	color: var(--color-primary);
+	background: var(--color-primary-light);
+}
+
+/* === Product Search === */
+.product-search {
+	background: white;
+	border-radius: var(--radius-lg);
+	padding: var(--spacing-lg);
+	box-shadow: var(--shadow-lg);
+	border: 2px solid var(--color-primary-light);
+}
+
+.product-search__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: var(--spacing-md);
+}
+
+.product-search__heading {
+	font-size: var(--font-size-lg);
+	font-weight: 600;
+	color: var(--color-gray-700);
+}
+
+.product-search__close {
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	color: var(--color-gray-500);
+	padding: var(--spacing-xs);
+	border-radius: var(--radius-sm);
+	transition: color 0.15s;
+}
+
+.product-search__close:hover {
+	color: var(--color-gray-900);
+}
+
+.product-search__original {
+	font-size: var(--font-size-sm);
+	color: var(--color-gray-500);
+	margin-bottom: var(--spacing-md);
+	padding: var(--spacing-sm);
+	background: var(--color-warning-light);
+	border-radius: var(--radius-sm);
+}
+
+.product-search__input-wrapper {
+	position: relative;
+	margin-bottom: var(--spacing-md);
+}
+
+.product-search__input {
+	width: 100%;
+	padding: var(--spacing-md);
+	border: 2px solid var(--color-gray-200);
+	border-radius: var(--radius-md);
+	font-size: var(--font-size-lg);
+	outline: none;
+	transition: border-color 0.15s;
+}
+
+.product-search__input:focus {
+	border-color: var(--color-primary);
+}
+
+.product-search__loading {
+	position: absolute;
+	right: var(--spacing-md);
+	top: 50%;
+	transform: translateY(-50%);
+	width: 20px;
+	height: 20px;
+	border: 2px solid var(--color-gray-200);
+	border-top-color: var(--color-primary);
+	border-radius: var(--radius-full);
+	animation: spin 0.8s linear infinite;
+}
+
+.product-search__error {
+	color: var(--color-danger);
+	font-size: var(--font-size-sm);
+	padding: var(--spacing-sm);
+	background: var(--color-danger-light);
+	border-radius: var(--radius-sm);
+	margin-bottom: var(--spacing-md);
+}
+
+.product-search__registering {
+	color: var(--color-primary);
+	font-size: var(--font-size-sm);
+	padding: var(--spacing-sm);
+	margin-bottom: var(--spacing-md);
+}
+
+.product-search__results {
+	list-style: none;
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-sm);
+	max-height: 300px;
+	overflow-y: auto;
+}
+
+.product-search__result-button {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	width: 100%;
+	padding: var(--spacing-md);
+	border: 1px solid var(--color-gray-200);
+	border-radius: var(--radius-md);
+	background: transparent;
+	cursor: pointer;
+	font-size: var(--font-size-base);
+	text-align: left;
+	transition: all 0.15s;
+	-webkit-tap-highlight-color: transparent;
+}
+
+.product-search__result-button:hover:not(:disabled) {
+	border-color: var(--color-success);
+	background: var(--color-success-light);
+}
+
+.product-search__result-button:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+.product-search__result-name {
+	font-weight: 500;
+	flex: 1;
+}
+
+.product-search__result-details {
+	display: flex;
+	gap: var(--spacing-md);
+	font-size: var(--font-size-sm);
+	color: var(--color-gray-500);
+}
+
+.product-search__no-results {
+	text-align: center;
+	color: var(--color-gray-500);
+	font-size: var(--font-size-sm);
+	padding: var(--spacing-lg);
+}
+
+/* === Confirmed Product === */
+.confirmed-product {
+	background: var(--color-success-light);
+	border: 2px solid var(--color-success);
+	border-radius: var(--radius-lg);
+	padding: var(--spacing-lg);
+	text-align: center;
+}
+
+.confirmed-product__heading {
+	font-size: var(--font-size-lg);
+	font-weight: 600;
+	color: var(--color-success);
+	margin-bottom: var(--spacing-sm);
+}
+
+.confirmed-product__name {
+	font-size: var(--font-size-xl);
+	font-weight: 700;
+	margin-bottom: var(--spacing-sm);
+}
+
+.confirmed-product__quantity {
+	font-size: var(--font-size-base);
+	color: var(--color-gray-700);
+	margin-bottom: var(--spacing-md);
+}
+
+.confirmed-product__reset {
+	padding: var(--spacing-sm) var(--spacing-lg);
+	border: 1px solid var(--color-gray-300);
+	border-radius: var(--radius-md);
+	background: white;
+	cursor: pointer;
+	font-size: var(--font-size-base);
+	transition: all 0.15s;
+}
+
+.confirmed-product__reset:hover {
+	border-color: var(--color-primary);
+	background: var(--color-primary-light);
+}
+
+/* === Alias Feedback === */
+.alias-feedback {
+	font-size: var(--font-size-sm);
+	padding: var(--spacing-sm) var(--spacing-md);
+	border-radius: var(--radius-md);
+	margin-top: var(--spacing-md);
+	text-align: center;
+}
+
+.alias-feedback--success {
+	background: var(--color-success-light);
+	color: var(--color-success);
+}
+
+.alias-feedback--error {
+	background: var(--color-danger-light);
+	color: var(--color-danger);
+}
+
+/* === Responsive: Tablet (768px+) === */
+@media (min-width: 768px) {
+	.pos-voice-concierge {
+		padding: var(--spacing-2xl);
+	}
+
+	.mic-button {
+		width: 140px;
+		height: 140px;
+	}
+
+	.match-list__button {
+		padding: var(--spacing-md) var(--spacing-lg);
+	}
+
+	.product-search__results {
+		max-height: 400px;
+	}
+}
+
+/* === Responsive: Small screens (<480px) === */
+@media (max-width: 480px) {
+	.pos-voice-concierge {
+		padding: var(--spacing-md);
+	}
+
+	.pos-voice-concierge__title {
+		font-size: var(--font-size-xl);
+	}
+
+	.mic-button {
+		width: 100px;
+		height: 100px;
+	}
+
+	.mic-button__icon svg {
+		width: 24px;
+		height: 24px;
+	}
+
+	.match-list__button {
+		flex-direction: column;
+		align-items: flex-start;
+		gap: var(--spacing-xs);
+	}
+
+	.match-list__details {
+		width: 100%;
+	}
+
+	.product-search__result-button {
+		flex-direction: column;
+		align-items: flex-start;
+		gap: var(--spacing-xs);
+	}
+}
+
+/* === Touch targets: minimum 44x44px for accessibility === */
+@media (pointer: coarse) {
+	.mic-button {
+		min-width: 120px;
+		min-height: 120px;
+	}
+
+	.match-list__button {
+		min-height: 48px;
+	}
+
+	.product-search__result-button {
+		min-height: 48px;
+	}
+
+	.product-search__input {
+		min-height: 48px;
+	}
+}

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2,27 +2,57 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App";
+import type { UseProductSearchReturn } from "./hooks/useProductSearch";
+import type { UseTtsReturn } from "./hooks/useTts";
 import type { UseVoiceReturn } from "./hooks/useVoice";
 
 const mockStartListening = vi.fn().mockResolvedValue(undefined);
 const mockStopListening = vi.fn();
+const mockSpeak = vi.fn();
+const mockCancelSpeech = vi.fn();
+const mockSearchProducts = vi.fn().mockResolvedValue(undefined);
+const mockRegisterAlias = vi.fn().mockResolvedValue({ success: true, message: "登録完了" });
+const mockClearSearch = vi.fn();
 
 let mockVoiceReturn: UseVoiceReturn;
+let mockTtsReturn: UseTtsReturn;
+let mockProductSearchReturn: UseProductSearchReturn;
 
 vi.mock("./hooks/useVoice", () => ({
 	useVoice: () => mockVoiceReturn,
 }));
 
+vi.mock("./hooks/useTts", () => ({
+	useTts: () => mockTtsReturn,
+}));
+
+vi.mock("./hooks/useProductSearch", () => ({
+	useProductSearch: () => mockProductSearchReturn,
+}));
+
 describe("App", () => {
 	beforeEach(() => {
-		mockStartListening.mockClear();
-		mockStopListening.mockClear();
+		vi.clearAllMocks();
 		mockVoiceReturn = {
 			state: "idle",
 			result: null,
 			error: null,
 			startListening: mockStartListening,
 			stopListening: mockStopListening,
+		};
+		mockTtsReturn = {
+			ttsState: "idle",
+			speak: mockSpeak,
+			cancelSpeech: mockCancelSpeech,
+		};
+		mockProductSearchReturn = {
+			searchResults: [],
+			isSearching: false,
+			searchError: null,
+			isRegistering: false,
+			searchProducts: mockSearchProducts,
+			registerAlias: mockRegisterAlias,
+			clearSearch: mockClearSearch,
 		};
 	});
 
@@ -60,12 +90,6 @@ describe("App", () => {
 		expect(mockStopListening).toHaveBeenCalledOnce();
 	});
 
-	it("shows processing state", () => {
-		mockVoiceReturn = { ...mockVoiceReturn, state: "processing" };
-		render(<App />);
-		expect(screen.getByRole("button", { name: "停止" })).toBeDefined();
-	});
-
 	it("shows error message when error occurs", () => {
 		mockVoiceReturn = {
 			...mockVoiceReturn,
@@ -96,9 +120,9 @@ describe("App", () => {
 			},
 		};
 		render(<App />);
-		expect(screen.getByText("認識結果: コカコーラ 2本")).toBeDefined();
-		expect(screen.getByText("信頼度: 95%")).toBeDefined();
-		expect(screen.getByText(/コカ・コーラ 500ml/)).toBeDefined();
+		expect(screen.getByText("コカコーラ 2本")).toBeDefined();
+		expect(screen.getByText("信頼度:")).toBeDefined();
+		expect(screen.getByText("コカ・コーラ 500ml")).toBeDefined();
 	});
 
 	it("shows retry button in error state", async () => {
@@ -112,5 +136,122 @@ describe("App", () => {
 		const button = screen.getByRole("button", { name: "音声入力開始" });
 		await user.click(button);
 		expect(mockStartListening).toHaveBeenCalledOnce();
+	});
+
+	it("shows match list with candidates", () => {
+		mockVoiceReturn = {
+			...mockVoiceReturn,
+			result: {
+				transcript: "コカコーラ",
+				confidence: 0.9,
+				isFinal: true,
+				matches: [
+					{ productId: "P001", productName: "コカ・コーラ 500ml", score: 95, quantity: 2 },
+					{ productId: "P002", productName: "コカ・コーラ 350ml", score: 88, quantity: 1 },
+				],
+			},
+		};
+		render(<App />);
+		expect(screen.getByText("商品候補")).toBeDefined();
+		expect(screen.getByText("コカ・コーラ 500ml")).toBeDefined();
+		expect(screen.getByText("コカ・コーラ 350ml")).toBeDefined();
+	});
+
+	it("shows confirmed product when a match is selected", async () => {
+		const user = userEvent.setup();
+		mockVoiceReturn = {
+			...mockVoiceReturn,
+			result: {
+				transcript: "コカコーラ",
+				confidence: 0.9,
+				isFinal: true,
+				matches: [{ productId: "P001", productName: "コカ・コーラ 500ml", score: 95, quantity: 2 }],
+			},
+		};
+		render(<App />);
+
+		await user.click(screen.getByLabelText("コカ・コーラ 500ml を選択 (スコア: 95%)"));
+
+		expect(screen.getByText("商品確定")).toBeDefined();
+		expect(screen.getByText("コカ・コーラ 500ml")).toBeDefined();
+		expect(screen.getByText("数量: 2")).toBeDefined();
+	});
+
+	it("calls TTS when a match is selected", async () => {
+		const user = userEvent.setup();
+		mockVoiceReturn = {
+			...mockVoiceReturn,
+			result: {
+				transcript: "コカコーラ",
+				confidence: 0.9,
+				isFinal: true,
+				matches: [{ productId: "P001", productName: "コカ・コーラ 500ml", score: 95, quantity: 2 }],
+			},
+		};
+		render(<App />);
+
+		await user.click(screen.getByLabelText("コカ・コーラ 500ml を選択 (スコア: 95%)"));
+
+		expect(mockSpeak).toHaveBeenCalledWith("コカ・コーラ 500ml、2点で登録しました");
+	});
+
+	it("shows manual search button when matches are available", () => {
+		mockVoiceReturn = {
+			...mockVoiceReturn,
+			result: {
+				transcript: "コカコーラ",
+				confidence: 0.9,
+				isFinal: true,
+				matches: [{ productId: "P001", productName: "コカ・コーラ 500ml", score: 95, quantity: 2 }],
+			},
+		};
+		render(<App />);
+
+		expect(screen.getByText("正しい商品が見つからない場合はこちら")).toBeDefined();
+	});
+
+	it("opens search dialog when manual search button is clicked", async () => {
+		const user = userEvent.setup();
+		mockVoiceReturn = {
+			...mockVoiceReturn,
+			result: {
+				transcript: "コカコーラ",
+				confidence: 0.9,
+				isFinal: true,
+				matches: [{ productId: "P001", productName: "コカ・コーラ 500ml", score: 95, quantity: 2 }],
+			},
+		};
+		render(<App />);
+
+		await user.click(screen.getByText("正しい商品が見つからない場合はこちら"));
+
+		expect(screen.getByRole("dialog", { name: "商品検索" })).toBeDefined();
+	});
+
+	it("shows TTS status when speaking", () => {
+		mockTtsReturn = { ...mockTtsReturn, ttsState: "speaking" };
+		render(<App />);
+
+		expect(screen.getByText("読み上げ中...")).toBeDefined();
+	});
+
+	it("resets state when clear button is clicked", async () => {
+		const user = userEvent.setup();
+		mockVoiceReturn = {
+			...mockVoiceReturn,
+			result: {
+				transcript: "コカコーラ",
+				confidence: 0.9,
+				isFinal: true,
+				matches: [{ productId: "P001", productName: "コカ・コーラ 500ml", score: 95, quantity: 2 }],
+			},
+		};
+		render(<App />);
+
+		await user.click(screen.getByLabelText("コカ・コーラ 500ml を選択 (スコア: 95%)"));
+		expect(screen.getByText("商品確定")).toBeDefined();
+
+		await user.click(screen.getByText("クリア"));
+		expect(screen.queryByText("商品確定")).toBeNull();
 	});
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,52 +1,163 @@
+import { useCallback, useState } from "react";
+import "./App.css";
+import { MatchList } from "./components/MatchList";
+import { MicButton } from "./components/MicButton";
+import { ProductSearch } from "./components/ProductSearch";
+import { TranscriptDisplay } from "./components/TranscriptDisplay";
+import { useProductSearch } from "./hooks/useProductSearch";
+import { useTts } from "./hooks/useTts";
 import { useVoice } from "./hooks/useVoice";
-import type { ProductMatch } from "./hooks/useVoice";
+import type { AliasRegistration, AliasRegistrationResponse, ProductMatch, ProductSearchResult } from "./types";
+
+/** 確定済み商品の情報 */
+interface ConfirmedProduct {
+	readonly productId: string;
+	readonly productName: string;
+	readonly quantity: number;
+}
+
+/** 辞書登録のフィードバック */
+interface AliasFeedback {
+	readonly success: boolean;
+	readonly message: string;
+}
 
 export function App(): React.JSX.Element {
 	const { state, result, error, startListening, stopListening } = useVoice();
+	const { ttsState, speak } = useTts();
+	const { searchResults, isSearching, searchError, isRegistering, searchProducts, registerAlias, clearSearch } =
+		useProductSearch();
 
-	const handleMicClick = (): void => {
+	const [selectedProductId, setSelectedProductId] = useState<string | null>(null);
+	const [confirmedProduct, setConfirmedProduct] = useState<ConfirmedProduct | null>(null);
+	const [showSearch, setShowSearch] = useState(false);
+	const [aliasFeedback, setAliasFeedback] = useState<AliasFeedback | null>(null);
+
+	const handleMicClick = useCallback((): void => {
 		if (state === "idle" || state === "error") {
+			setConfirmedProduct(null);
+			setSelectedProductId(null);
+			setShowSearch(false);
+			setAliasFeedback(null);
 			void startListening();
 		} else {
 			stopListening();
 		}
-	};
+	}, [state, startListening, stopListening]);
+
+	const handleSelectMatch = useCallback(
+		(match: ProductMatch): void => {
+			setSelectedProductId(match.productId);
+			setConfirmedProduct({
+				productId: match.productId,
+				productName: match.productName,
+				quantity: match.quantity,
+			});
+			setShowSearch(false);
+			speak(`${match.productName}、${String(match.quantity)}点で登録しました`);
+		},
+		[speak],
+	);
+
+	const handleOpenSearch = useCallback((): void => {
+		setShowSearch(true);
+		clearSearch();
+	}, [clearSearch]);
+
+	const handleCloseSearch = useCallback((): void => {
+		setShowSearch(false);
+		clearSearch();
+	}, [clearSearch]);
+
+	const handleSelectCorrect = useCallback(
+		(product: ProductSearchResult, registration: AliasRegistration): void => {
+			setConfirmedProduct({
+				productId: product.productId,
+				productName: product.productName,
+				quantity: 1,
+			});
+			setSelectedProductId(product.productId);
+			setShowSearch(false);
+
+			speak(`${product.productName}に修正しました`);
+
+			void registerAlias(registration).then((response: AliasRegistrationResponse) => {
+				setAliasFeedback({
+					success: response.success,
+					message: response.success
+						? `「${registration.spokenForm}」→「${product.productName}」を辞書に登録しました`
+						: response.message,
+				});
+			});
+		},
+		[speak, registerAlias],
+	);
+
+	const handleReset = useCallback((): void => {
+		setConfirmedProduct(null);
+		setSelectedProductId(null);
+		setShowSearch(false);
+		setAliasFeedback(null);
+	}, []);
 
 	return (
 		<div className="pos-voice-concierge">
-			<h1>POS Voice Concierge</h1>
-			<button
-				type="button"
-				onClick={handleMicClick}
-				aria-label={state === "listening" || state === "processing" ? "停止" : "音声入力開始"}
-			>
-				{state === "idle" && "🎤 音声入力"}
-				{state === "listening" && "⏹ 停止"}
-				{state === "processing" && "⏳ 処理中..."}
-				{state === "error" && "🎤 再試行"}
-			</button>
+			<header className="pos-voice-concierge__header">
+				<h1 className="pos-voice-concierge__title">POS Voice Concierge</h1>
+			</header>
+
+			<div className="pos-voice-concierge__controls">
+				<MicButton state={state} onClick={handleMicClick} />
+				{ttsState === "speaking" && <output className="pos-voice-concierge__tts-status">読み上げ中...</output>}
+			</div>
+
 			{error && (
-				<div className="error" role="alert">
+				<div className="error-display" role="alert">
 					<p>{error}</p>
 				</div>
 			)}
-			{result && (
-				<div className="transcript">
-					<p>認識結果: {result.transcript}</p>
-					{result.confidence > 0 && <p>信頼度: {Math.round(result.confidence * 100)}%</p>}
-					{result.matches.length > 0 && (
-						<div className="matches">
-							<h2>商品候補</h2>
-							<ul>
-								{result.matches.map((match: ProductMatch) => (
-									<li key={match.productId}>
-										{match.productName} (スコア: {Math.round(match.score)}%)
-									</li>
-								))}
-							</ul>
-						</div>
-					)}
-				</div>
+
+			{result && <TranscriptDisplay result={result} />}
+
+			{result && result.matches.length > 0 && !confirmedProduct && (
+				<>
+					<MatchList matches={result.matches} onSelect={handleSelectMatch} selectedProductId={selectedProductId} />
+					<button type="button" className="match-list__correct-button" onClick={handleOpenSearch}>
+						正しい商品が見つからない場合はこちら
+					</button>
+				</>
+			)}
+
+			{showSearch && result && (
+				<ProductSearch
+					originalTranscript={result.transcript}
+					searchResults={searchResults}
+					isSearching={isSearching}
+					searchError={searchError}
+					isRegistering={isRegistering}
+					onSearch={searchProducts}
+					onSelectCorrect={handleSelectCorrect}
+					onClose={handleCloseSearch}
+				/>
+			)}
+
+			{confirmedProduct && (
+				<output className="confirmed-product">
+					<h2 className="confirmed-product__heading">商品確定</h2>
+					<p className="confirmed-product__name">{confirmedProduct.productName}</p>
+					<p className="confirmed-product__quantity">数量: {confirmedProduct.quantity}</p>
+					<button type="button" className="confirmed-product__reset" onClick={handleReset}>
+						クリア
+					</button>
+				</output>
+			)}
+
+			{aliasFeedback && (
+				<output
+					className={`alias-feedback ${aliasFeedback.success ? "alias-feedback--success" : "alias-feedback--error"}`}
+				>
+					{aliasFeedback.message}
+				</output>
 			)}
 		</div>
 	);

--- a/frontend/src/components/MatchList.test.tsx
+++ b/frontend/src/components/MatchList.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { ProductMatch } from "../types";
+import { MatchList } from "./MatchList";
+
+const sampleMatches: ProductMatch[] = [
+	{ productId: "P001", productName: "コカ・コーラ 500ml", score: 95, quantity: 2 },
+	{ productId: "P002", productName: "コカ・コーラ 350ml", score: 88, quantity: 1 },
+	{ productId: "P003", productName: "コカ・コーラ ゼロ 500ml", score: 82, quantity: 1 },
+];
+
+describe("MatchList", () => {
+	it("renders empty message when no matches", () => {
+		render(<MatchList matches={[]} onSelect={vi.fn()} selectedProductId={null} />);
+
+		expect(screen.getByText("マッチする商品が見つかりませんでした")).toBeDefined();
+	});
+
+	it("renders all match candidates", () => {
+		render(<MatchList matches={sampleMatches} onSelect={vi.fn()} selectedProductId={null} />);
+
+		expect(screen.getByText("コカ・コーラ 500ml")).toBeDefined();
+		expect(screen.getByText("コカ・コーラ 350ml")).toBeDefined();
+		expect(screen.getByText("コカ・コーラ ゼロ 500ml")).toBeDefined();
+	});
+
+	it("displays scores for each match", () => {
+		render(<MatchList matches={sampleMatches} onSelect={vi.fn()} selectedProductId={null} />);
+
+		expect(screen.getByText("スコア: 95%")).toBeDefined();
+		expect(screen.getByText("スコア: 88%")).toBeDefined();
+		expect(screen.getByText("スコア: 82%")).toBeDefined();
+	});
+
+	it("displays quantity when greater than zero", () => {
+		render(<MatchList matches={sampleMatches} onSelect={vi.fn()} selectedProductId={null} />);
+
+		expect(screen.getByText("数量: 2")).toBeDefined();
+	});
+
+	it("calls onSelect when a candidate is clicked", async () => {
+		const user = userEvent.setup();
+		const onSelect = vi.fn();
+		render(<MatchList matches={sampleMatches} onSelect={onSelect} selectedProductId={null} />);
+
+		await user.click(screen.getByText("コカ・コーラ 500ml"));
+
+		expect(onSelect).toHaveBeenCalledOnce();
+		expect(onSelect).toHaveBeenCalledWith(sampleMatches[0]);
+	});
+
+	it("highlights selected product", () => {
+		const { container } = render(<MatchList matches={sampleMatches} onSelect={vi.fn()} selectedProductId="P001" />);
+
+		const selectedItem = container.querySelector(".match-list__item--selected");
+		expect(selectedItem).not.toBeNull();
+	});
+
+	it("marks selected button with aria-pressed", () => {
+		render(<MatchList matches={sampleMatches} onSelect={vi.fn()} selectedProductId="P001" />);
+
+		const buttons = screen.getAllByRole("button");
+		expect(buttons[0]?.getAttribute("aria-pressed")).toBe("true");
+		expect(buttons[1]?.getAttribute("aria-pressed")).toBe("false");
+	});
+
+	it("has candidates container with aria-label", () => {
+		const { container } = render(<MatchList matches={sampleMatches} onSelect={vi.fn()} selectedProductId={null} />);
+
+		const items = container.querySelector('[aria-label="商品候補リスト"]');
+		expect(items).not.toBeNull();
+	});
+
+	it("provides accessible label for each candidate button", () => {
+		render(<MatchList matches={sampleMatches} onSelect={vi.fn()} selectedProductId={null} />);
+
+		expect(screen.getByLabelText("コカ・コーラ 500ml を選択 (スコア: 95%)")).toBeDefined();
+	});
+});

--- a/frontend/src/components/MatchList.tsx
+++ b/frontend/src/components/MatchList.tsx
@@ -1,0 +1,55 @@
+import type { ProductMatch } from "../types";
+
+interface MatchListProps {
+	readonly matches: readonly ProductMatch[];
+	readonly onSelect: (match: ProductMatch) => void;
+	readonly selectedProductId: string | null;
+}
+
+/**
+ * マッチング候補リストコンポーネント.
+ *
+ * ファジーマッチングの候補をスコア順に表示し、
+ * タップで商品を確定できる。
+ */
+export function MatchList({ matches, onSelect, selectedProductId }: MatchListProps): React.JSX.Element {
+	if (matches.length === 0) {
+		return (
+			<div className="match-list match-list--empty">
+				<p>マッチする商品が見つかりませんでした</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="match-list">
+			<h2 className="match-list__heading">商品候補</h2>
+			<div className="match-list__items" aria-label="商品候補リスト">
+				{matches.map((match) => {
+					const isSelected = match.productId === selectedProductId;
+					return (
+						<div
+							key={match.productId}
+							className={`match-list__item ${isSelected ? "match-list__item--selected" : ""}`}
+							data-selected={isSelected}
+						>
+							<button
+								type="button"
+								className="match-list__button"
+								onClick={() => onSelect(match)}
+								aria-label={`${match.productName} を選択 (スコア: ${String(Math.round(match.score))}%)`}
+								aria-pressed={isSelected}
+							>
+								<span className="match-list__product-name">{match.productName}</span>
+								<span className="match-list__details">
+									<span className="match-list__score">スコア: {Math.round(match.score)}%</span>
+									{match.quantity > 0 && <span className="match-list__quantity">数量: {match.quantity}</span>}
+								</span>
+							</button>
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/components/MicButton.test.tsx
+++ b/frontend/src/components/MicButton.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { MicButton } from "./MicButton";
+
+describe("MicButton", () => {
+	it("renders idle state with mic label", () => {
+		render(<MicButton state="idle" onClick={vi.fn()} />);
+
+		const button = screen.getByRole("button", { name: "音声入力開始" });
+		expect(button).toBeDefined();
+		expect(button.textContent).toContain("音声入力");
+	});
+
+	it("renders listening state with stop label", () => {
+		render(<MicButton state="listening" onClick={vi.fn()} />);
+
+		const button = screen.getByRole("button", { name: "停止" });
+		expect(button).toBeDefined();
+		expect(button.textContent).toContain("録音中...");
+	});
+
+	it("renders processing state and is disabled", () => {
+		render(<MicButton state="processing" onClick={vi.fn()} />);
+
+		const button = screen.getByRole("button", { name: "停止" });
+		expect(button).toBeDefined();
+		expect((button as HTMLButtonElement).disabled).toBe(true);
+		expect(button.textContent).toContain("処理中...");
+	});
+
+	it("renders error state with retry label", () => {
+		render(<MicButton state="error" onClick={vi.fn()} />);
+
+		const button = screen.getByRole("button", { name: "音声入力開始" });
+		expect(button).toBeDefined();
+		expect(button.textContent).toContain("再試行");
+	});
+
+	it("calls onClick when clicked in idle state", async () => {
+		const user = userEvent.setup();
+		const onClick = vi.fn();
+		render(<MicButton state="idle" onClick={onClick} />);
+
+		await user.click(screen.getByRole("button"));
+		expect(onClick).toHaveBeenCalledOnce();
+	});
+
+	it("calls onClick when clicked in listening state", async () => {
+		const user = userEvent.setup();
+		const onClick = vi.fn();
+		render(<MicButton state="listening" onClick={onClick} />);
+
+		await user.click(screen.getByRole("button"));
+		expect(onClick).toHaveBeenCalledOnce();
+	});
+
+	it("does not call onClick when processing", async () => {
+		const user = userEvent.setup();
+		const onClick = vi.fn();
+		render(<MicButton state="processing" onClick={onClick} />);
+
+		await user.click(screen.getByRole("button"));
+		expect(onClick).not.toHaveBeenCalled();
+	});
+
+	it("shows pulse animation in listening state", () => {
+		const { container } = render(<MicButton state="listening" onClick={vi.fn()} />);
+
+		const pulse = container.querySelector(".mic-button__pulse");
+		expect(pulse).not.toBeNull();
+	});
+
+	it("does not show pulse animation in idle state", () => {
+		const { container } = render(<MicButton state="idle" onClick={vi.fn()} />);
+
+		const pulse = container.querySelector(".mic-button__pulse");
+		expect(pulse).toBeNull();
+	});
+
+	it("has correct CSS class for state", () => {
+		const { container } = render(<MicButton state="listening" onClick={vi.fn()} />);
+
+		const button = container.querySelector(".mic-button--listening");
+		expect(button).not.toBeNull();
+	});
+});

--- a/frontend/src/components/MicButton.tsx
+++ b/frontend/src/components/MicButton.tsx
@@ -1,0 +1,62 @@
+import type { VoiceState } from "../types";
+
+interface MicButtonProps {
+	readonly state: VoiceState;
+	readonly onClick: () => void;
+}
+
+const STATE_LABELS: Record<VoiceState, string> = {
+	idle: "音声入力開始",
+	listening: "停止",
+	processing: "停止",
+	error: "音声入力開始",
+};
+
+const STATE_TEXT: Record<VoiceState, string> = {
+	idle: "音声入力",
+	listening: "録音中...",
+	processing: "処理中...",
+	error: "再試行",
+};
+
+/**
+ * マイクボタンコンポーネント.
+ *
+ * 録音状態に応じて視覚フィードバックを提供する。
+ * - idle: マイクアイコン
+ * - listening: パルスアニメーション付き録音中表示
+ * - processing: スピナー付き処理中表示
+ * - error: 再試行ボタン
+ */
+export function MicButton({ state, onClick }: MicButtonProps): React.JSX.Element {
+	const isActive = state === "listening" || state === "processing";
+
+	return (
+		<button
+			type="button"
+			className={`mic-button mic-button--${state}`}
+			onClick={onClick}
+			aria-label={STATE_LABELS[state]}
+			disabled={state === "processing"}
+		>
+			<span className="mic-button__icon" aria-hidden="true">
+				{state === "processing" ? (
+					<span className="mic-button__spinner" />
+				) : (
+					<svg viewBox="0 0 24 24" width="28" height="28" fill="currentColor" aria-hidden="true">
+						{isActive ? (
+							<rect x="6" y="6" width="12" height="12" rx="2" />
+						) : (
+							<>
+								<path d="M12 14c1.66 0 3-1.34 3-3V5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3z" />
+								<path d="M17 11c0 2.76-2.24 5-5 5s-5-2.24-5-5H5c0 3.53 2.61 6.43 6 6.92V21h2v-3.08c3.39-.49 6-3.39 6-6.92h-2z" />
+							</>
+						)}
+					</svg>
+				)}
+			</span>
+			<span className="mic-button__text">{STATE_TEXT[state]}</span>
+			{state === "listening" && <span className="mic-button__pulse" aria-hidden="true" />}
+		</button>
+	);
+}

--- a/frontend/src/components/ProductSearch.test.tsx
+++ b/frontend/src/components/ProductSearch.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ProductSearch } from "./ProductSearch";
+
+const defaultProps = {
+	originalTranscript: "コカコーラ",
+	searchResults: [],
+	isSearching: false,
+	searchError: null,
+	isRegistering: false,
+	onSearch: vi.fn().mockResolvedValue(undefined),
+	onSelectCorrect: vi.fn(),
+	onClose: vi.fn(),
+};
+
+describe("ProductSearch", () => {
+	it("renders the search dialog", () => {
+		render(<ProductSearch {...defaultProps} />);
+
+		expect(screen.getByRole("dialog", { name: "商品検索" })).toBeDefined();
+		expect(screen.getByText("商品を手動で検索")).toBeDefined();
+	});
+
+	it("shows original transcript", () => {
+		render(<ProductSearch {...defaultProps} />);
+
+		expect(screen.getByText("コカコーラ")).toBeDefined();
+	});
+
+	it("calls onSearch when typing in search input", async () => {
+		const user = userEvent.setup();
+		const onSearch = vi.fn().mockResolvedValue(undefined);
+
+		render(<ProductSearch {...defaultProps} onSearch={onSearch} />);
+
+		const input = screen.getByLabelText("商品名検索");
+		await user.type(input, "コカ");
+
+		expect(onSearch).toHaveBeenCalled();
+	});
+
+	it("renders search results", () => {
+		const searchResults = [
+			{ productId: "P001", productName: "コカ・コーラ 500ml", janCode: "4902102000001", price: 150 },
+			{ productId: "P002", productName: "コカ・コーラ 350ml", janCode: "4902102000002", price: 120 },
+		];
+
+		render(<ProductSearch {...defaultProps} searchResults={searchResults} />);
+
+		expect(screen.getByText("コカ・コーラ 500ml")).toBeDefined();
+		expect(screen.getByText("コカ・コーラ 350ml")).toBeDefined();
+	});
+
+	it("displays JAN code and price in results", () => {
+		const searchResults = [
+			{ productId: "P001", productName: "コカ・コーラ 500ml", janCode: "4902102000001", price: 150 },
+		];
+
+		render(<ProductSearch {...defaultProps} searchResults={searchResults} />);
+
+		expect(screen.getByText("JAN: 4902102000001")).toBeDefined();
+	});
+
+	it("calls onSelectCorrect with alias registration when product is selected", async () => {
+		const user = userEvent.setup();
+		const onSelectCorrect = vi.fn();
+		const searchResults = [
+			{ productId: "P001", productName: "コカ・コーラ 500ml", janCode: "4902102000001", price: 150 },
+		];
+
+		render(<ProductSearch {...defaultProps} searchResults={searchResults} onSelectCorrect={onSelectCorrect} />);
+
+		await user.click(screen.getByLabelText("コカ・コーラ 500ml を正しい商品として選択"));
+
+		expect(onSelectCorrect).toHaveBeenCalledOnce();
+		expect(onSelectCorrect).toHaveBeenCalledWith(searchResults[0], {
+			spokenForm: "コカコーラ",
+			productId: "P001",
+			productName: "コカ・コーラ 500ml",
+		});
+	});
+
+	it("calls onClose when close button is clicked", async () => {
+		const user = userEvent.setup();
+		const onClose = vi.fn();
+
+		render(<ProductSearch {...defaultProps} onClose={onClose} />);
+
+		await user.click(screen.getByLabelText("検索を閉じる"));
+
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+
+	it("shows search error", () => {
+		render(<ProductSearch {...defaultProps} searchError="検索に失敗しました" />);
+
+		expect(screen.getByRole("alert")).toBeDefined();
+		expect(screen.getByText("検索に失敗しました")).toBeDefined();
+	});
+
+	it("shows loading indicator when searching", () => {
+		render(<ProductSearch {...defaultProps} isSearching={true} />);
+
+		expect(screen.getByLabelText("検索中")).toBeDefined();
+	});
+
+	it("shows registering status", () => {
+		render(<ProductSearch {...defaultProps} isRegistering={true} />);
+
+		expect(screen.getByText("辞書に登録中...")).toBeDefined();
+	});
+
+	it("disables result buttons when registering", () => {
+		const searchResults = [
+			{ productId: "P001", productName: "コカ・コーラ 500ml", janCode: "4902102000001", price: 150 },
+		];
+
+		render(<ProductSearch {...defaultProps} searchResults={searchResults} isRegistering={true} />);
+
+		const button = screen.getByLabelText("コカ・コーラ 500ml を正しい商品として選択");
+		expect((button as HTMLButtonElement).disabled).toBe(true);
+	});
+
+	it("shows no results message when search returns empty", async () => {
+		const user = userEvent.setup();
+		render(<ProductSearch {...defaultProps} />);
+
+		const input = screen.getByLabelText("商品名検索");
+		await user.type(input, "存在しない商品");
+
+		expect(screen.getByText("該当する商品が見つかりませんでした")).toBeDefined();
+	});
+});

--- a/frontend/src/components/ProductSearch.tsx
+++ b/frontend/src/components/ProductSearch.tsx
@@ -1,0 +1,122 @@
+import { useCallback, useState } from "react";
+import type { AliasRegistration, ProductSearchResult } from "../types";
+
+interface ProductSearchProps {
+	/** 元の認識テキスト（辞書登録時の spoken_form として使用） */
+	readonly originalTranscript: string;
+	/** 検索結果 */
+	readonly searchResults: readonly ProductSearchResult[];
+	/** 検索中かどうか */
+	readonly isSearching: boolean;
+	/** 検索エラー */
+	readonly searchError: string | null;
+	/** 辞書登録中かどうか */
+	readonly isRegistering: boolean;
+	/** 検索実行 */
+	readonly onSearch: (query: string) => Promise<void>;
+	/** 商品選択時（辞書登録を含む） */
+	readonly onSelectCorrect: (product: ProductSearchResult, registration: AliasRegistration) => void;
+	/** 検索パネルを閉じる */
+	readonly onClose: () => void;
+}
+
+/**
+ * 手動修正用の商品検索コンポーネント.
+ *
+ * 誤認識時に正しい商品を検索・選択し、
+ * 表記ゆれ辞書への登録を行う。
+ */
+export function ProductSearch({
+	originalTranscript,
+	searchResults,
+	isSearching,
+	searchError,
+	isRegistering,
+	onSearch,
+	onSelectCorrect,
+	onClose,
+}: ProductSearchProps): React.JSX.Element {
+	const [searchQuery, setSearchQuery] = useState("");
+
+	const handleInputChange = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			const value = e.target.value;
+			setSearchQuery(value);
+			void onSearch(value);
+		},
+		[onSearch],
+	);
+
+	const handleSelectProduct = useCallback(
+		(product: ProductSearchResult) => {
+			const registration: AliasRegistration = {
+				spokenForm: originalTranscript,
+				productId: product.productId,
+				productName: product.productName,
+			};
+			onSelectCorrect(product, registration);
+		},
+		[originalTranscript, onSelectCorrect],
+	);
+
+	return (
+		<dialog className="product-search" open aria-label="商品検索">
+			<div className="product-search__header">
+				<h2 className="product-search__heading">商品を手動で検索</h2>
+				<button type="button" className="product-search__close" onClick={onClose} aria-label="検索を閉じる">
+					<svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor" aria-hidden="true">
+						<path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+					</svg>
+				</button>
+			</div>
+			<p className="product-search__original">
+				認識テキスト: <strong>{originalTranscript}</strong>
+			</p>
+			<div className="product-search__input-wrapper">
+				<input
+					type="search"
+					className="product-search__input"
+					placeholder="商品名を入力して検索..."
+					value={searchQuery}
+					onChange={handleInputChange}
+					aria-label="商品名検索"
+				/>
+				{isSearching && <span className="product-search__loading" aria-label="検索中" />}
+			</div>
+
+			{searchError && (
+				<div className="product-search__error" role="alert">
+					{searchError}
+				</div>
+			)}
+
+			{isRegistering && <output className="product-search__registering">辞書に登録中...</output>}
+
+			{searchResults.length > 0 && (
+				<div className="product-search__results" aria-label="検索結果">
+					{searchResults.map((product) => (
+						<div key={product.productId} className="product-search__result-item">
+							<button
+								type="button"
+								className="product-search__result-button"
+								onClick={() => handleSelectProduct(product)}
+								disabled={isRegistering}
+								aria-label={`${product.productName} を正しい商品として選択`}
+							>
+								<span className="product-search__result-name">{product.productName}</span>
+								<span className="product-search__result-details">
+									{product.janCode && <span className="product-search__result-jan">JAN: {product.janCode}</span>}
+									{product.price > 0 && <span className="product-search__result-price">&yen;{product.price}</span>}
+								</span>
+							</button>
+						</div>
+					))}
+				</div>
+			)}
+
+			{searchQuery.length > 0 && !isSearching && searchResults.length === 0 && !searchError && (
+				<p className="product-search__no-results">該当する商品が見つかりませんでした</p>
+			)}
+		</dialog>
+	);
+}

--- a/frontend/src/components/TranscriptDisplay.test.tsx
+++ b/frontend/src/components/TranscriptDisplay.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TranscriptDisplay } from "./TranscriptDisplay";
+
+describe("TranscriptDisplay", () => {
+	it("renders transcript text", () => {
+		render(
+			<TranscriptDisplay result={{ transcript: "コカコーラ 2本", confidence: 0.95, isFinal: true, matches: [] }} />,
+		);
+
+		expect(screen.getByText("コカコーラ 2本")).toBeDefined();
+	});
+
+	it("renders confidence percentage", () => {
+		render(<TranscriptDisplay result={{ transcript: "テスト", confidence: 0.85, isFinal: true, matches: [] }} />);
+
+		expect(screen.getByText("信頼度:")).toBeDefined();
+		const allValues = screen.getAllByText("85%");
+		expect(allValues.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("does not render confidence when zero", () => {
+		render(<TranscriptDisplay result={{ transcript: "テスト", confidence: 0, isFinal: true, matches: [] }} />);
+
+		expect(screen.queryByText("信頼度:")).toBeNull();
+	});
+
+	it("shows interim label when not final", () => {
+		render(<TranscriptDisplay result={{ transcript: "コカ...", confidence: 0.5, isFinal: false, matches: [] }} />);
+
+		expect(screen.getByText("認識中...")).toBeDefined();
+	});
+
+	it("does not show interim label when final", () => {
+		render(<TranscriptDisplay result={{ transcript: "コカコーラ", confidence: 0.95, isFinal: true, matches: [] }} />);
+
+		expect(screen.queryByText("認識中...")).toBeNull();
+	});
+
+	it("applies interim CSS class when not final", () => {
+		const { container } = render(
+			<TranscriptDisplay result={{ transcript: "コカ...", confidence: 0.5, isFinal: false, matches: [] }} />,
+		);
+
+		const interimText = container.querySelector(".transcript-display__text--interim");
+		expect(interimText).not.toBeNull();
+	});
+
+	it("has output element for live region", () => {
+		const { container } = render(
+			<TranscriptDisplay result={{ transcript: "テスト", confidence: 0.9, isFinal: true, matches: [] }} />,
+		);
+
+		const output = container.querySelector("output");
+		expect(output).not.toBeNull();
+	});
+
+	it("renders confidence progress element with correct attributes", () => {
+		const { container } = render(
+			<TranscriptDisplay result={{ transcript: "テスト", confidence: 0.75, isFinal: true, matches: [] }} />,
+		);
+
+		const progress = container.querySelector("progress");
+		expect(progress).not.toBeNull();
+		expect(progress?.getAttribute("value")).toBe("75");
+		expect(progress?.getAttribute("max")).toBe("100");
+		expect(progress?.getAttribute("aria-label")).toBe("信頼度 75%");
+	});
+});

--- a/frontend/src/components/TranscriptDisplay.tsx
+++ b/frontend/src/components/TranscriptDisplay.tsx
@@ -1,0 +1,39 @@
+import type { RecognitionResult } from "../types";
+
+interface TranscriptDisplayProps {
+	readonly result: RecognitionResult;
+}
+
+/**
+ * 認識結果のリアルタイム表示コンポーネント.
+ *
+ * 音声認識のテキスト結果と信頼度を表示する。
+ * isFinal でない場合は暫定結果として視覚的に区別する。
+ */
+export function TranscriptDisplay({ result }: TranscriptDisplayProps): React.JSX.Element {
+	const confidencePercent = Math.round(result.confidence * 100);
+
+	return (
+		<output className="transcript-display" aria-live="polite">
+			<h2 className="transcript-display__heading">認識結果</h2>
+			<p className={`transcript-display__text ${result.isFinal ? "" : "transcript-display__text--interim"}`}>
+				{result.transcript}
+			</p>
+			{result.confidence > 0 && (
+				<div className="transcript-display__confidence">
+					<span className="transcript-display__confidence-label">信頼度:</span>
+					<span className="transcript-display__confidence-value">{confidencePercent}%</span>
+					<progress
+						className="transcript-display__confidence-bar"
+						value={confidencePercent}
+						max={100}
+						aria-label={`信頼度 ${String(confidencePercent)}%`}
+					>
+						{confidencePercent}%
+					</progress>
+				</div>
+			)}
+			{!result.isFinal && <p className="transcript-display__interim-label">認識中...</p>}
+		</output>
+	);
+}

--- a/frontend/src/hooks/useProductSearch.test.ts
+++ b/frontend/src/hooks/useProductSearch.test.ts
@@ -1,0 +1,140 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useProductSearch } from "./useProductSearch";
+
+describe("useProductSearch", () => {
+	const mockFetch = vi.fn();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+		vi.stubGlobal("fetch", mockFetch);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("starts with empty results", () => {
+		const { result } = renderHook(() => useProductSearch());
+
+		expect(result.current.searchResults).toEqual([]);
+		expect(result.current.isSearching).toBe(false);
+		expect(result.current.searchError).toBeNull();
+		expect(result.current.isRegistering).toBe(false);
+	});
+
+	it("clears results when search query is empty", async () => {
+		const { result } = renderHook(() => useProductSearch());
+
+		await act(async () => {
+			await result.current.searchProducts("");
+		});
+
+		expect(result.current.searchResults).toEqual([]);
+		expect(mockFetch).not.toHaveBeenCalled();
+	});
+
+	it("searches products after debounce", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => [
+				{
+					productId: "P001",
+					productName: "コカ・コーラ 500ml",
+					janCode: "4902102000001",
+					price: 150,
+				},
+			],
+		});
+
+		const { result } = renderHook(() => useProductSearch({ debounceMs: 100 }));
+
+		const searchPromise = act(async () => {
+			const p = result.current.searchProducts("コカ");
+			vi.advanceTimersByTime(100);
+			await p;
+		});
+
+		await searchPromise;
+
+		expect(mockFetch).toHaveBeenCalledOnce();
+		expect(result.current.searchResults).toHaveLength(1);
+		expect(result.current.searchResults[0]?.productName).toBe("コカ・コーラ 500ml");
+	});
+
+	it("handles search API error", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: false,
+			status: 500,
+		});
+
+		const { result } = renderHook(() => useProductSearch({ debounceMs: 0 }));
+
+		await act(async () => {
+			const p = result.current.searchProducts("コカ");
+			vi.advanceTimersByTime(0);
+			await p;
+		});
+
+		expect(result.current.searchError).toBe("検索に失敗しました (500)");
+		expect(result.current.searchResults).toEqual([]);
+	});
+
+	it("registers alias successfully", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				success: true,
+				message: "登録完了",
+			}),
+		});
+
+		const { result } = renderHook(() => useProductSearch());
+
+		let response: { success: boolean; message: string } | undefined;
+		await act(async () => {
+			response = await result.current.registerAlias({
+				spokenForm: "コカコーラ",
+				productId: "P001",
+				productName: "コカ・コーラ 500ml",
+			});
+		});
+
+		expect(mockFetch).toHaveBeenCalledWith("/api/aliases", expect.objectContaining({ method: "POST" }));
+		expect(response?.success).toBe(true);
+	});
+
+	it("handles alias registration failure", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: false,
+			status: 500,
+		});
+
+		const { result } = renderHook(() => useProductSearch());
+
+		let response: { success: boolean; message: string } | undefined;
+		await act(async () => {
+			response = await result.current.registerAlias({
+				spokenForm: "コカコーラ",
+				productId: "P001",
+				productName: "コカ・コーラ 500ml",
+			});
+		});
+
+		expect(response?.success).toBe(false);
+		expect(response?.message).toBe("辞書登録に失敗しました (500)");
+	});
+
+	it("clears search results", () => {
+		const { result } = renderHook(() => useProductSearch());
+
+		act(() => {
+			result.current.clearSearch();
+		});
+
+		expect(result.current.searchResults).toEqual([]);
+		expect(result.current.searchError).toBeNull();
+		expect(result.current.isSearching).toBe(false);
+	});
+});

--- a/frontend/src/hooks/useProductSearch.ts
+++ b/frontend/src/hooks/useProductSearch.ts
@@ -1,0 +1,180 @@
+import { useCallback, useRef, useState } from "react";
+import type { AliasRegistration, AliasRegistrationResponse, ProductSearchResult, RawProductSearchData } from "../types";
+
+/** useProductSearch フックの戻り値 */
+export interface UseProductSearchReturn {
+	/** 検索結果 */
+	readonly searchResults: readonly ProductSearchResult[];
+	/** 検索中かどうか */
+	readonly isSearching: boolean;
+	/** 検索エラー */
+	readonly searchError: string | null;
+	/** 辞書登録中かどうか */
+	readonly isRegistering: boolean;
+	/** 商品名で検索する */
+	readonly searchProducts: (query: string) => Promise<void>;
+	/** 表記ゆれ辞書に登録する */
+	readonly registerAlias: (registration: AliasRegistration) => Promise<AliasRegistrationResponse>;
+	/** 検索結果をクリアする */
+	readonly clearSearch: () => void;
+}
+
+/** useProductSearch フックのオプション */
+interface UseProductSearchOptions {
+	/** 商品検索APIのベースURL */
+	readonly apiBaseUrl?: string;
+	/** デバウンス間隔 (ms) */
+	readonly debounceMs?: number;
+}
+
+const DEFAULT_API_BASE_URL = "/api";
+const DEFAULT_DEBOUNCE_MS = 300;
+
+/** APIレスポンスをProductSearchResult配列にパースする */
+function parseSearchResults(rawData: readonly RawProductSearchData[]): ProductSearchResult[] {
+	return rawData.map((item) => ({
+		productId: String(item.productId ?? ""),
+		productName: String(item.productName ?? ""),
+		janCode: String(item.janCode ?? ""),
+		price: Number(item.price ?? 0),
+	}));
+}
+
+/** エラーオブジェクトからメッセージを取得する */
+function getErrorMessage(err: unknown, fallback: string): string {
+	return err instanceof Error ? err.message : fallback;
+}
+
+/**
+ * 商品検索と表記ゆれ辞書登録を管理するフック.
+ *
+ * 手動修正時の商品検索と、誤認識の修正データを辞書APIに登録する。
+ */
+export function useProductSearch(options: UseProductSearchOptions = {}): UseProductSearchReturn {
+	const { apiBaseUrl = DEFAULT_API_BASE_URL, debounceMs = DEFAULT_DEBOUNCE_MS } = options;
+
+	const [searchResults, setSearchResults] = useState<readonly ProductSearchResult[]>([]);
+	const [isSearching, setIsSearching] = useState(false);
+	const [searchError, setSearchError] = useState<string | null>(null);
+	const [isRegistering, setIsRegistering] = useState(false);
+
+	const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const abortControllerRef = useRef<AbortController | null>(null);
+
+	const cancelPending = useCallback(() => {
+		if (debounceTimerRef.current) {
+			clearTimeout(debounceTimerRef.current);
+		}
+		if (abortControllerRef.current) {
+			abortControllerRef.current.abort();
+		}
+	}, []);
+
+	const fetchProducts = useCallback(
+		async (query: string, signal: AbortSignal): Promise<void> => {
+			const response = await fetch(`${apiBaseUrl}/products/search?q=${encodeURIComponent(query)}`, {
+				signal,
+				headers: { Accept: "application/json" },
+			});
+
+			if (!response.ok) {
+				throw new Error(`検索に失敗しました (${String(response.status)})`);
+			}
+
+			const rawData = (await response.json()) as readonly RawProductSearchData[];
+			setSearchResults(parseSearchResults(rawData));
+		},
+		[apiBaseUrl],
+	);
+
+	const searchProducts = useCallback(
+		async (query: string): Promise<void> => {
+			cancelPending();
+
+			if (query.trim().length === 0) {
+				setSearchResults([]);
+				setSearchError(null);
+				return;
+			}
+
+			await new Promise<void>((resolve) => {
+				debounceTimerRef.current = setTimeout(resolve, debounceMs);
+			});
+
+			setIsSearching(true);
+			setSearchError(null);
+
+			const controller = new AbortController();
+			abortControllerRef.current = controller;
+
+			try {
+				await fetchProducts(query, controller.signal);
+			} catch (err: unknown) {
+				if (err instanceof DOMException && err.name === "AbortError") {
+					return;
+				}
+				setSearchError(getErrorMessage(err, "商品検索に失敗しました"));
+				setSearchResults([]);
+			} finally {
+				setIsSearching(false);
+			}
+		},
+		[cancelPending, fetchProducts, debounceMs],
+	);
+
+	const registerAlias = useCallback(
+		async (registration: AliasRegistration): Promise<AliasRegistrationResponse> => {
+			setIsRegistering(true);
+
+			try {
+				const response = await fetch(`${apiBaseUrl}/aliases`, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Accept: "application/json",
+					},
+					body: JSON.stringify({
+						spokenForm: registration.spokenForm,
+						productId: registration.productId,
+						productName: registration.productName,
+					}),
+				});
+
+				if (!response.ok) {
+					throw new Error(`辞書登録に失敗しました (${String(response.status)})`);
+				}
+
+				const data = (await response.json()) as { success?: unknown; message?: unknown };
+				return {
+					success: Boolean(data.success),
+					message: String(data.message ?? "登録完了"),
+				};
+			} catch (err: unknown) {
+				return {
+					success: false,
+					message: getErrorMessage(err, "辞書登録に失敗しました"),
+				};
+			} finally {
+				setIsRegistering(false);
+			}
+		},
+		[apiBaseUrl],
+	);
+
+	const clearSearch = useCallback(() => {
+		cancelPending();
+		setSearchResults([]);
+		setSearchError(null);
+		setIsSearching(false);
+	}, [cancelPending]);
+
+	return {
+		searchResults,
+		isSearching,
+		searchError,
+		isRegistering,
+		searchProducts,
+		registerAlias,
+		clearSearch,
+	};
+}

--- a/frontend/src/hooks/useTts.test.ts
+++ b/frontend/src/hooks/useTts.test.ts
@@ -1,0 +1,137 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useTts } from "./useTts";
+
+describe("useTts", () => {
+	let mockUtterance: {
+		lang: string;
+		rate: number;
+		onstart: (() => void) | null;
+		onend: (() => void) | null;
+		onerror: (() => void) | null;
+	};
+
+	const mockSpeak = vi.fn();
+	const mockCancel = vi.fn();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		mockUtterance = {
+			lang: "",
+			rate: 1,
+			onstart: null,
+			onend: null,
+			onerror: null,
+		};
+
+		vi.stubGlobal(
+			"SpeechSynthesisUtterance",
+			vi.fn(() => mockUtterance),
+		);
+
+		Object.defineProperty(window, "speechSynthesis", {
+			value: {
+				speak: mockSpeak,
+				cancel: mockCancel,
+			},
+			writable: true,
+			configurable: true,
+		});
+	});
+
+	it("starts in idle state", () => {
+		const { result } = renderHook(() => useTts());
+
+		expect(result.current.ttsState).toBe("idle");
+	});
+
+	it("calls speechSynthesis.speak with correct parameters", () => {
+		const { result } = renderHook(() => useTts());
+
+		act(() => {
+			result.current.speak("テスト");
+		});
+
+		expect(mockCancel).toHaveBeenCalledOnce();
+		expect(mockSpeak).toHaveBeenCalledOnce();
+		expect(mockUtterance.lang).toBe("ja-JP");
+		expect(mockUtterance.rate).toBe(1);
+	});
+
+	it("transitions to speaking state on start", () => {
+		const { result } = renderHook(() => useTts());
+
+		act(() => {
+			result.current.speak("テスト");
+		});
+
+		act(() => {
+			mockUtterance.onstart?.();
+		});
+
+		expect(result.current.ttsState).toBe("speaking");
+	});
+
+	it("transitions back to idle on end", () => {
+		const { result } = renderHook(() => useTts());
+
+		act(() => {
+			result.current.speak("テスト");
+		});
+
+		act(() => {
+			mockUtterance.onstart?.();
+		});
+
+		act(() => {
+			mockUtterance.onend?.();
+		});
+
+		expect(result.current.ttsState).toBe("idle");
+	});
+
+	it("transitions to idle on error", () => {
+		const { result } = renderHook(() => useTts());
+
+		act(() => {
+			result.current.speak("テスト");
+		});
+
+		act(() => {
+			mockUtterance.onstart?.();
+		});
+
+		act(() => {
+			mockUtterance.onerror?.();
+		});
+
+		expect(result.current.ttsState).toBe("idle");
+	});
+
+	it("cancels speech when cancelSpeech is called", () => {
+		const { result } = renderHook(() => useTts());
+
+		act(() => {
+			result.current.speak("テスト");
+		});
+
+		act(() => {
+			result.current.cancelSpeech();
+		});
+
+		expect(mockCancel).toHaveBeenCalledTimes(2);
+		expect(result.current.ttsState).toBe("idle");
+	});
+
+	it("uses custom language and rate", () => {
+		const { result } = renderHook(() => useTts({ lang: "en-US", rate: 1.5 }));
+
+		act(() => {
+			result.current.speak("test");
+		});
+
+		expect(mockUtterance.lang).toBe("en-US");
+		expect(mockUtterance.rate).toBe(1.5);
+	});
+});

--- a/frontend/src/hooks/useTts.ts
+++ b/frontend/src/hooks/useTts.ts
@@ -1,0 +1,82 @@
+import { useCallback, useRef, useState } from "react";
+
+/** TTS の状態 */
+export type TtsState = "idle" | "speaking";
+
+/** useTts フックの戻り値 */
+export interface UseTtsReturn {
+	/** 現在の TTS 状態 */
+	readonly ttsState: TtsState;
+	/** テキストを音声で読み上げる */
+	readonly speak: (text: string) => void;
+	/** 読み上げを停止する */
+	readonly cancelSpeech: () => void;
+}
+
+/** useTts フックのオプション */
+interface UseTtsOptions {
+	/** 音声の言語 (デフォルト: ja-JP) */
+	readonly lang?: string;
+	/** 読み上げ速度 (デフォルト: 1.0) */
+	readonly rate?: number;
+}
+
+/**
+ * Web Speech API SpeechSynthesis を使った TTS フック.
+ *
+ * テキストを日本語音声で読み上げる。
+ * 読み上げ中の状態管理と、読み上げ停止機能を提供する。
+ */
+export function useTts(options: UseTtsOptions = {}): UseTtsReturn {
+	const { lang = "ja-JP", rate = 1.0 } = options;
+
+	const [ttsState, setTtsState] = useState<TtsState>("idle");
+	const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
+
+	const speak = useCallback(
+		(text: string) => {
+			if (typeof window === "undefined" || !window.speechSynthesis) {
+				return;
+			}
+
+			window.speechSynthesis.cancel();
+
+			const utterance = new SpeechSynthesisUtterance(text);
+			utterance.lang = lang;
+			utterance.rate = rate;
+
+			utterance.onstart = () => {
+				setTtsState("speaking");
+			};
+
+			utterance.onend = () => {
+				setTtsState("idle");
+				utteranceRef.current = null;
+			};
+
+			utterance.onerror = () => {
+				setTtsState("idle");
+				utteranceRef.current = null;
+			};
+
+			utteranceRef.current = utterance;
+			window.speechSynthesis.speak(utterance);
+		},
+		[lang, rate],
+	);
+
+	const cancelSpeech = useCallback(() => {
+		if (typeof window === "undefined" || !window.speechSynthesis) {
+			return;
+		}
+		window.speechSynthesis.cancel();
+		setTtsState("idle");
+		utteranceRef.current = null;
+	}, []);
+
+	return {
+		ttsState,
+		speak,
+		cancelSpeech,
+	};
+}

--- a/frontend/src/hooks/useVoice.ts
+++ b/frontend/src/hooks/useVoice.ts
@@ -1,23 +1,7 @@
 import { useCallback, useRef, useState } from "react";
+import type { ProductMatch, RawProductMatchData, RawRecognitionData, RecognitionResult, VoiceState } from "../types";
 
-/** 音声認識の状態 */
-export type VoiceState = "idle" | "listening" | "processing" | "error";
-
-/** 商品マッチング結果 */
-export interface ProductMatch {
-	readonly productId: string;
-	readonly productName: string;
-	readonly score: number;
-	readonly quantity: number;
-}
-
-/** 認識結果 */
-export interface RecognitionResult {
-	readonly transcript: string;
-	readonly confidence: number;
-	readonly isFinal: boolean;
-	readonly matches: readonly ProductMatch[];
-}
+export type { ProductMatch, RecognitionResult, VoiceState };
 
 /** useVoice フックの戻り値 */
 export interface UseVoiceReturn {
@@ -195,21 +179,6 @@ function getSupportedMimeType(): string {
 	}
 
 	return "audio/webm";
-}
-
-/** パース用の型定義 */
-interface RawRecognitionData {
-	transcript?: unknown;
-	confidence?: unknown;
-	isFinal?: unknown;
-	matches?: unknown;
-}
-
-interface RawProductMatchData {
-	productId?: unknown;
-	productName?: unknown;
-	score?: unknown;
-	quantity?: unknown;
 }
 
 /** JSON 文字列を RecognitionResult にパースする */

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,63 @@
+/** 商品マッチング結果 */
+export interface ProductMatch {
+	readonly productId: string;
+	readonly productName: string;
+	readonly score: number;
+	readonly quantity: number;
+}
+
+/** 認識結果 */
+export interface RecognitionResult {
+	readonly transcript: string;
+	readonly confidence: number;
+	readonly isFinal: boolean;
+	readonly matches: readonly ProductMatch[];
+}
+
+/** 音声認識の状態 */
+export type VoiceState = "idle" | "listening" | "processing" | "error";
+
+/** 表記ゆれ辞書登録リクエスト */
+export interface AliasRegistration {
+	readonly spokenForm: string;
+	readonly productId: string;
+	readonly productName: string;
+}
+
+/** 表記ゆれ辞書登録レスポンス */
+export interface AliasRegistrationResponse {
+	readonly success: boolean;
+	readonly message: string;
+}
+
+/** 商品検索結果 */
+export interface ProductSearchResult {
+	readonly productId: string;
+	readonly productName: string;
+	readonly janCode: string;
+	readonly price: number;
+}
+
+/** パース用の型定義 */
+export interface RawRecognitionData {
+	transcript?: unknown;
+	confidence?: unknown;
+	isFinal?: unknown;
+	matches?: unknown;
+}
+
+/** パース用のマッチデータ */
+export interface RawProductMatchData {
+	productId?: unknown;
+	productName?: unknown;
+	score?: unknown;
+	quantity?: unknown;
+}
+
+/** 商品検索APIレスポンス */
+export interface RawProductSearchData {
+	productId?: unknown;
+	productName?: unknown;
+	janCode?: unknown;
+	price?: unknown;
+}


### PR DESCRIPTION
## Summary
- マイクボタン（録音開始/停止、パルスアニメーション、処理中スピナー）を実装
- Web Audio API + MediaRecorder でマイク入力をキャプチャし WebSocket 経由で backend に送信（既存 useVoice フック活用）
- 認識結果のリアルタイム表示（テキスト + 信頼度プログレスバー + 暫定/確定の視覚区別）
- マッチング候補の選択UI（候補一覧からタップで商品確定 + TTS読み上げ）
- 誤認識時の手動修正UI（商品名検索 + 正しい商品の選択）
- 手動修正時に表記ゆれ辞書登録APIを呼び出し、登録結果のフィードバック表示
- Web Speech API SpeechSynthesis によるTTS（商品確定時・修正時の音声レスポンス）
- レスポンシブ対応CSS（タブレット/モバイル/タッチデバイス、44px以上のタッチターゲット）
- コンポーネント分割: MicButton, TranscriptDisplay, MatchList, ProductSearch
- フック分割: useVoice（既存拡張）, useTts（新規）, useProductSearch（新規）
- 型定義を types.ts に集約、any型不使用
- 全74テスト合格（vitest + React Testing Library）
- biome / oxlint / tsc 全通過

## 新規ファイル
- `frontend/src/types.ts` - 共有型定義
- `frontend/src/App.css` - レスポンシブスタイル
- `frontend/src/hooks/useTts.ts` - TTS フック
- `frontend/src/hooks/useProductSearch.ts` - 商品検索 + 辞書登録フック
- `frontend/src/components/MicButton.tsx` - マイクボタン
- `frontend/src/components/TranscriptDisplay.tsx` - 認識結果表示
- `frontend/src/components/MatchList.tsx` - マッチング候補リスト
- `frontend/src/components/ProductSearch.tsx` - 手動修正検索ダイアログ
- 各コンポーネント・フックのテストファイル（8ファイル）

## Closes
Closes #8

## Test plan
- [x] `make check` 全通過（format, lint, test, build）
- [x] 74テスト合格（App: 15, MicButton: 10, TranscriptDisplay: 8, MatchList: 9, ProductSearch: 12, useVoice: 6, useTts: 7, useProductSearch: 7）
- [x] biome check（a11yルール含む）エラーゼロ
- [x] oxlint エラーゼロ
- [x] TypeScript 型チェック通過（noExplicitAny, strict）