### PR TITLE
build(deps): backend build.gradle.kts メジャー更新統合 (Quarkus 3.36.1 / Kotlin 2.4.0 / protobuf 4.35.0)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    kotlin("jvm") version "2.3.20"
-    kotlin("plugin.allopen") version "2.3.21"
-    id("io.quarkus") version "3.34.5"
+    kotlin("jvm") version "2.4.0"
+    kotlin("plugin.allopen") version "2.4.0"
+    id("io.quarkus") version "3.36.1"
     id("io.gitlab.arturbosch.detekt") version "1.23.8"
 }
 
@@ -22,7 +22,7 @@ dependencies {
     implementation("io.quarkus:quarkus-grpc")
     implementation("io.quarkus:quarkus-websockets")
     implementation("io.quarkus:quarkus-security")
-    implementation("com.google.protobuf:protobuf-kotlin:4.34.1")
+    implementation("com.google.protobuf:protobuf-kotlin:4.35.0")
     implementation("io.quarkus:quarkus-jdbc-postgresql")
     implementation("io.quarkus:quarkus-hibernate-orm-panache-kotlin")
     implementation("io.quarkus:quarkus-flyway")

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,4 +1,4 @@
-quarkusPluginVersion=3.34.1
+quarkusPluginVersion=3.36.1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=3.34.1
+quarkusPlatformVersion=3.36.1

--- a/backend/src/main/kotlin/com/akaitigo/posvoice/auth/ApiKeyAuthMechanism.kt
+++ b/backend/src/main/kotlin/com/akaitigo/posvoice/auth/ApiKeyAuthMechanism.kt
@@ -43,7 +43,7 @@ class ApiKeyAuthMechanism : HttpAuthenticationMechanism {
     }
 
     private fun extractApiKey(context: RoutingContext): String? {
-        val authHeader = context.request().getHeader(AUTHORIZATION_HEADER)
+        val authHeader: String? = context.request().getHeader(AUTHORIZATION_HEADER)
         return authHeader
             ?.takeIf { it.startsWith(BEARER_PREFIX) }
             ?.substring(BEARER_PREFIX.length)


### PR DESCRIPTION
## 概要
同一ファイル `backend/build.gradle.kts` を編集する dependabot PR **#60 / #62 / #63 / #64** を、直列マージ時の相互コンフリクトを避けるため1ブランチに統合しました。マージ後に4本を superseded クローズします。

## 変更内容
| 対象 | 変更 | 元PR |
|---|---|---|
| `io.quarkus` プラグイン | 3.34.5 → 3.36.1 | #62 |
| `quarkusPlatformVersion`/`quarkusPluginVersion` (gradle.properties) | 3.34.1 → 3.36.1 | #62 併せ込み |
| Kotlin `jvm` | 2.3.20 → 2.4.0 | #64 |
| Kotlin `plugin.allopen` | 2.3.21 → 2.4.0 | #63 |
| `protobuf-kotlin` | 4.34.1 → 4.35.0 | #60 |
| `ApiKeyAuthMechanism.kt` | `authHeader` に明示的 `String?` 型注釈 | Kotlin 2.4.0 追従修正 |

## 判断根拠 / 追従修正
- **BOM 整合**: dependabot #62 は `io.quarkus` プラグインのみ更新し、`gradle.properties` の platform BOM (3.34.1) を取り残していた。プラグインと BOM のバージョン不整合を避けるため BOM も 3.36.1 に揃えた。
- **Quarkus 3.36 系採用**: 3.37 系にある「全デフォルト値付き Kotlin data class のボディが壊れる」リグレッションを回避。3.36.1 は非該当。
- **Kotlin 2.4.0 コンパイルエラー修正**: `context.request().getHeader()` の戻り値は Vert.x の `io.vertx.codegen.annotations.Nullable`(TYPE_USE, コンパイル classpath 外)で注釈されており、Kotlin 2.4.0 は推論型に含まれるこの注釈クラスが解決不能でコンパイルエラーになる。`val authHeader: String?` と明示的に型付けして推論を短絡させ解消。挙動は不変(認証ロジックに変更なし)。

## 検証
- ローカル `./gradlew build` 成功。テスト19件全パス (HealthResource 1 / QueryResource 13 / VoiceEngineClient 1 / VoiceWebSocket 4、失敗0)。detekt 通過。