### PR TITLE
build(deps): voice-engine 残りの要求フロア更新 (pytest 9 / grpcio-tools 1.80)

### DIFF
--- a/voice-engine/pyproject.toml
+++ b/voice-engine/pyproject.toml
@@ -5,7 +5,7 @@ description = "Voice recognition engine with Whisper and fuzzy matching for POS"
 requires-python = ">=3.12"
 dependencies = [
     "grpcio>=1.80.0",
-    "grpcio-tools>=1.60",
+    "grpcio-tools>=1.80.0",
     "openai-whisper>=20240930",
     "rapidfuzz>=3.6",
     "numpy>=1.26",
@@ -14,7 +14,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.0",
+    "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
     "pytest-asyncio>=0.24",
     "ruff>=0.8",


### PR DESCRIPTION
## 概要
`voice-engine/pyproject.toml` の隣接行を編集する dependabot PR **#42** (pytest `>=8.0`→`>=9.0.3`) と **#45** (grpcio-tools `>=1.60`→`>=1.80.0`) を統合。この2本は隣接行のため個別マージで相互コンフリクトし、`@dependabot rebase` も収束しなかった(#42 には dependabot が "no longer updatable" と返答)ため手動統合しました。マージ後に #42/#45 を superseded クローズします。

## 判断根拠
- 要求フロア(下限)の引き上げのみ。CI の `pip install -e ".[dev]"` は元々制約を満たす**最新版**を導入するため、main は既に pytest 9.x / grpcio-tools 1.80+ で緑。実挙動の変化はない。
- pre-commit フックのテストスイート(voice-engine pytest 含む)ローカル通過。