### PR TITLE
ci: setup-java v5 / setup-node v6 へ更新（Node 20 deprecation）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm


### PR DESCRIPTION
#36 の残作業。dependabot PR (#65 checkout, #38 fetch-metadata) で大半は更新済みだが、setup-node@v4（Node 20 ランタイム）と setup-java@v4 の更新 PR は dependabot が未作成だったため手動対応。actionlint パス済み。Refs #36