### PR TITLE
セキュリティ修正: WebSocket認証・DB TLS・入力バリデーション・例外漏洩

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 DATABASE_URL=postgresql://localhost:5432/pos_voice_concierge
 DATABASE_USER=
 DATABASE_PASSWORD=
+# TLS mode for the DB connection (本番は require 必須。ローカルの非TLS Postgres は disable)
+DATABASE_SSL_MODE=require
 
 # === Voice Engine ===
 WHISPER_MODEL=base
@@ -16,6 +18,8 @@ GRPC_CLIENT_PORT=50051
 # === Frontend ===
 VITE_API_URL=http://localhost:8080
 VITE_WS_URL=ws://localhost:8080/ws
+# WebSocket ハンドシェイク認証用の API キー（POS_VOICE_API_KEY と同じ値をビルド時に注入）
+VITE_POS_VOICE_API_KEY=
 
 # === Authentication ===
 # API Key for REST endpoint authentication (required)

--- a/backend/src/main/kotlin/com/akaitigo/posvoice/auth/ApiKeyAuthMechanism.kt
+++ b/backend/src/main/kotlin/com/akaitigo/posvoice/auth/ApiKeyAuthMechanism.kt
@@ -23,6 +23,37 @@ class ApiKeyAuthMechanism : HttpAuthenticationMechanism {
         private const val BEARER_PREFIX = "Bearer "
         private const val AUTHORIZATION_HEADER = "Authorization"
         private const val UNAUTHORIZED_STATUS = 401
+        private const val ACCESS_TOKEN_PARAM = "access_token"
+        private const val WS_PATH_PREFIX = "/ws/"
+
+        /**
+         * リクエストからAPIキーを解決する.
+         *
+         * 優先順位:
+         * 1. 全パス共通で `Authorization: Bearer <key>` ヘッダー。
+         * 2. WebSocket パス（/ws/ 配下）に限り `access_token` クエリパラメータ。
+         *    ブラウザの WebSocket ハンドシェイクは任意ヘッダーを設定できないため、
+         *    クエリパラメータをフォールバックとして許可する（設計判断は ADR-0003 参照）。
+         *
+         * @param authHeader Authorization ヘッダーの値
+         * @param path リクエストパス
+         * @param accessToken access_token クエリパラメータの値
+         * @return 解決したAPIキー。存在しない場合は null。
+         */
+        fun resolveApiKey(authHeader: String?, path: String?, accessToken: String?): String? {
+            val fromHeader = authHeader
+                ?.takeIf { it.startsWith(BEARER_PREFIX) }
+                ?.substring(BEARER_PREFIX.length)
+                ?.trim()
+                ?.ifEmpty { null }
+            val isWsPath = path != null && path.startsWith(WS_PATH_PREFIX)
+            val fromQuery = if (isWsPath) {
+                accessToken?.trim()?.ifEmpty { null }
+            } else {
+                null
+            }
+            return fromHeader ?: fromQuery
+        }
     }
 
     override fun authenticate(
@@ -44,11 +75,8 @@ class ApiKeyAuthMechanism : HttpAuthenticationMechanism {
 
     private fun extractApiKey(context: RoutingContext): String? {
         val authHeader: String? = context.request().getHeader(AUTHORIZATION_HEADER)
-        return authHeader
-            ?.takeIf { it.startsWith(BEARER_PREFIX) }
-            ?.substring(BEARER_PREFIX.length)
-            ?.trim()
-            ?.ifEmpty { null }
+        val accessToken: String? = context.request().getParam(ACCESS_TOKEN_PARAM)
+        return resolveApiKey(authHeader, context.normalizedPath(), accessToken)
     }
 
     override fun getCredentialTypes(): Set<Class<out AuthenticationRequest>> {

--- a/backend/src/main/kotlin/com/akaitigo/posvoice/query/QueryResource.kt
+++ b/backend/src/main/kotlin/com/akaitigo/posvoice/query/QueryResource.kt
@@ -33,6 +33,8 @@ class QueryResource {
 
     companion object {
         private const val DEFAULT_TOP_N = 5
+        private const val MIN_TOP_N = 1
+        private const val MAX_TOP_N = 100
     }
 
     @Inject
@@ -119,7 +121,8 @@ class QueryResource {
         @QueryParam("limit") limit: Int?,
     ): Response {
         val effectivePeriod = period ?: "today"
-        val effectiveLimit = limit ?: DEFAULT_TOP_N
+        // 負数・ゼロ・過大値がそのまま LIMIT に渡らないよう [1, 100] に丸める
+        val effectiveLimit = (limit ?: DEFAULT_TOP_N).coerceIn(MIN_TOP_N, MAX_TOP_N)
         val (from, to, label) = resolvePeriod(effectivePeriod)
 
         val results = salesRepository.topProductsBetween(from, to, effectiveLimit)

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -13,11 +13,20 @@ quarkus.datasource.password=${DATABASE_PASSWORD:}
 quarkus.hibernate-orm.database.generation=none
 quarkus.flyway.migrate-at-start=true
 
+# Database TLS: CLAUDE.md の「全通信TLS 1.2+必須」に従い、本番/開発では sslmode=require。
+# DATABASE_SSL_MODE で上書き可（ローカルの非TLS Postgres は disable などに設定）。
+# test プロファイル(H2)には sslmode を渡さない（H2 は未対応プロパティを拒否するため）。
+pos-voice.database.ssl-mode=${DATABASE_SSL_MODE:require}
+%prod.quarkus.datasource.jdbc.additional-jdbc-properties.sslmode=${pos-voice.database.ssl-mode}
+%dev.quarkus.datasource.jdbc.additional-jdbc-properties.sslmode=${pos-voice.database.ssl-mode}
+
 # API Key authentication
 pos-voice.api-key=${POS_VOICE_API_KEY:}
 
-# Security: health endpoint is public, all /api/** require authentication
+# Security: health endpoint is public, /api/** と /ws/** は認証必須
 quarkus.http.auth.permission.public.paths=/health
 quarkus.http.auth.permission.public.policy=permit
 quarkus.http.auth.permission.api.paths=/api/*
 quarkus.http.auth.permission.api.policy=authenticated
+quarkus.http.auth.permission.ws.paths=/ws/*
+quarkus.http.auth.permission.ws.policy=authenticated

--- a/backend/src/test/kotlin/com/akaitigo/posvoice/DatabaseSslConfigTest.kt
+++ b/backend/src/test/kotlin/com/akaitigo/posvoice/DatabaseSslConfigTest.kt
@@ -1,0 +1,24 @@
+package com.akaitigo.posvoice
+
+import io.quarkus.test.junit.QuarkusTest
+import org.eclipse.microprofile.config.ConfigProvider
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * DB の TLS 設定（Issue #31）の回帰テスト.
+ *
+ * `pos-voice.database.ssl-mode` が既定で `require` に解決されることを検証する。
+ * 実際の `sslmode` JDBC プロパティは `%prod`/`%dev` プロファイルにのみ付与され、
+ * H2 を使う test プロファイルには渡らない。
+ */
+@QuarkusTest
+class DatabaseSslConfigTest {
+
+    @Test
+    fun `db ssl mode defaults to require`() {
+        val sslMode = ConfigProvider.getConfig()
+            .getValue("pos-voice.database.ssl-mode", String::class.java)
+        assertEquals("require", sslMode)
+    }
+}

--- a/backend/src/test/kotlin/com/akaitigo/posvoice/auth/ApiKeyAuthMechanismTest.kt
+++ b/backend/src/test/kotlin/com/akaitigo/posvoice/auth/ApiKeyAuthMechanismTest.kt
@@ -1,0 +1,48 @@
+package com.akaitigo.posvoice.auth
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * [ApiKeyAuthMechanism.resolveApiKey] の単体テスト.
+ *
+ * ヘッダー優先・WebSocket パス限定の access_token フォールバックを検証する。
+ */
+class ApiKeyAuthMechanismTest {
+
+    @Test
+    fun `bearer header is extracted for any path`() {
+        assertEquals("abc123", ApiKeyAuthMechanism.resolveApiKey("Bearer abc123", "/api/query/sales", null))
+    }
+
+    @Test
+    fun `access_token query param is accepted on ws paths`() {
+        assertEquals("wskey", ApiKeyAuthMechanism.resolveApiKey(null, "/ws/voice", "wskey"))
+    }
+
+    @Test
+    fun `access_token query param is ignored on non-ws paths`() {
+        assertNull(ApiKeyAuthMechanism.resolveApiKey(null, "/api/query/sales", "wskey"))
+    }
+
+    @Test
+    fun `header takes precedence over query param on ws path`() {
+        assertEquals("headerkey", ApiKeyAuthMechanism.resolveApiKey("Bearer headerkey", "/ws/voice", "querykey"))
+    }
+
+    @Test
+    fun `blank bearer token resolves to null`() {
+        assertNull(ApiKeyAuthMechanism.resolveApiKey("Bearer   ", "/ws/voice", null))
+    }
+
+    @Test
+    fun `blank access_token resolves to null`() {
+        assertNull(ApiKeyAuthMechanism.resolveApiKey(null, "/ws/voice", "   "))
+    }
+
+    @Test
+    fun `no credentials resolves to null`() {
+        assertNull(ApiKeyAuthMechanism.resolveApiKey(null, "/ws/voice", null))
+    }
+}

--- a/backend/src/test/kotlin/com/akaitigo/posvoice/query/QueryResourceTest.kt
+++ b/backend/src/test/kotlin/com/akaitigo/posvoice/query/QueryResourceTest.kt
@@ -138,6 +138,49 @@ class QueryResourceTest {
     }
 
     @Test
+    fun `websocket handshake without auth returns 401`() {
+        // Issue #25: /ws/** も認証必須。未認証ハンドシェイクは 401。
+        given()
+            .`when`().get("/ws/voice")
+            .then()
+            .statusCode(401)
+    }
+
+    @Test
+    fun `rest endpoint ignores access_token query param`() {
+        // access_token クエリは WebSocket パス限定。REST はヘッダーのみ受け付ける。
+        given()
+            .queryParam("access_token", TEST_API_KEY)
+            .`when`().get("/api/query/sales")
+            .then()
+            .statusCode(401)
+    }
+
+    @Test
+    fun `top products clamps negative limit without error`() {
+        // Issue #28: 負数の limit でも 500 にならず 200（LIMIT に不正値が渡らない）。
+        given()
+            .header("Authorization", "Bearer $TEST_API_KEY")
+            .queryParam("period", "today")
+            .queryParam("limit", -5)
+            .`when`().get("/api/query/top-products")
+            .then()
+            .statusCode(200)
+            .body("periodLabel", `is`("今日"))
+    }
+
+    @Test
+    fun `top products clamps oversized limit without error`() {
+        given()
+            .header("Authorization", "Bearer $TEST_API_KEY")
+            .queryParam("period", "today")
+            .queryParam("limit", 100000)
+            .`when`().get("/api/query/top-products")
+            .then()
+            .statusCode(200)
+    }
+
+    @Test
     fun `health endpoint is accessible without auth`() {
         given()
             .`when`().get("/health")

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -18,3 +18,5 @@ quarkus.http.auth.permission.public.paths=/health
 quarkus.http.auth.permission.public.policy=permit
 quarkus.http.auth.permission.api.paths=/api/*
 quarkus.http.auth.permission.api.policy=authenticated
+quarkus.http.auth.permission.ws.paths=/ws/*
+quarkus.http.auth.permission.ws.policy=authenticated

--- a/docs/adr/0003-websocket-authentication.md
+++ b/docs/adr/0003-websocket-authentication.md
@@ -1,0 +1,50 @@
+# ADR-0003: WebSocket エンドポイントの認証方式
+
+## ステータス
+
+Accepted
+
+## コンテキスト
+
+`/ws/voice` WebSocket エンドポイントは、当初 HTTP 認証ポリシー（`quarkus.http.auth.permission`）が `/api/*` のみを対象としており、`/ws/*` が認証対象から漏れていた（Issue #25）。認証されていないクライアントが音声 WebSocket に接続し、voice-engine への gRPC ストリームを消費できる状態だった。
+
+REST API は `Authorization: Bearer <API_KEY>` ヘッダーで認証している（`ApiKeyAuthMechanism`）。WebSocket にも同一の API キー基盤で認証をかけたいが、次の制約がある:
+
+- ブラウザの標準 `WebSocket` API は、ハンドシェイク（HTTP Upgrade）リクエストに任意のヘッダー（`Authorization` 含む）を設定できない。
+- したがって REST と同じ「ヘッダーにトークン」方式をブラウザ WebSocket に直接適用できない。
+
+## 決定
+
+### 1. `/ws/**` を認証必須にする
+
+`application.properties` に HTTP 認証ポリシーを追加し、WebSocket ハンドシェイク（HTTP GET Upgrade）を既存の Quarkus HTTP セキュリティ層で保護する。
+
+```properties
+quarkus.http.auth.permission.ws.paths=/ws/*
+quarkus.http.auth.permission.ws.policy=authenticated
+```
+
+ハンドシェイクは通常の HTTP リクエストとして Vert.x ルーターを通るため、既存の `ApiKeyAuthMechanism` がそのまま適用される。
+
+### 2. WebSocket は `access_token` クエリパラメータでの認証を許可する
+
+`ApiKeyAuthMechanism.resolveApiKey` を次の優先順位に拡張した:
+
+1. 全パス共通で `Authorization: Bearer <key>` ヘッダー（REST・非ブラウザクライアント用）。
+2. **`/ws/**` パスに限り** `access_token` クエリパラメータ（ブラウザ WebSocket 用フォールバック）。
+
+クエリパラメータによる認証を WebSocket パスに限定することで、REST エンドポイントでは引き続きヘッダーのみを受け付け、トークンが URL に露出する範囲を最小化する。フロントエンド（`useVoice`）はビルド時に注入された `VITE_POS_VOICE_API_KEY` を `?access_token=` として付与する。
+
+### 検討した代替案
+
+- **`Sec-WebSocket-Protocol`（サブプロトコル）にトークンを載せる**: ブラウザから設定可能でヘッダー方式に近いが、サーバーが選択したサブプロトコルをハンドシェイク応答でエコーバックする必要があり、`@ServerEndpoint` での実装が煩雑。トークンが応答ヘッダーにも現れる。MVP では見送り。
+- **Cookie 認証**: CSRF 対策とセッション管理が別途必要になり、ステートレスな API キー方式と整合しない。
+
+## 影響 / リスクと緩和策
+
+- **トークンが URL に載るリスク**: アクセスログ・プロキシログ・ブラウザ履歴にクエリパラメータが残り得る。緩和策:
+  - 本番では `wss://`（TLS）必須とし、転送中は URL ごと暗号化する（CLAUDE.md「全通信 TLS 1.2+ 必須」に整合）。
+  - リバースプロキシ／アプリのアクセスログで `access_token` クエリをマスクする設定を本番デプロイ時に行う。
+  - API キーは `openssl rand -hex 32` 相当の十分なエントロピーを持ち、漏洩時はローテーションする。
+- REST エンドポイントの認証面は変更なし（ヘッダーのみ）。`access_token` クエリは `/ws/**` 以外では無視される。
+- 将来トークンの短命化（ハンドシェイク専用の一時トークン発行）に移行する余地を残す。移行時は本 ADR を更新する。

--- a/frontend/src/hooks/useVoice.test.ts
+++ b/frontend/src/hooks/useVoice.test.ts
@@ -187,4 +187,24 @@ describe("useVoice", () => {
 		expect(result.current.state).toBe("error");
 		expect(result.current.error).toBe("WebSocket接続エラーが発生しました");
 	});
+
+	it("appends access_token query param to the WebSocket URL when apiKey is provided", async () => {
+		const { result } = renderHook(() => useVoice({ apiKey: "secret-key" }));
+
+		await act(async () => {
+			await result.current.startListening();
+		});
+
+		expect(WebSocket).toHaveBeenCalledWith(expect.stringContaining("access_token=secret-key"));
+	});
+
+	it("does not append access_token to the WebSocket URL when apiKey is empty", async () => {
+		const { result } = renderHook(() => useVoice({ apiKey: "" }));
+
+		await act(async () => {
+			await result.current.startListening();
+		});
+
+		expect(WebSocket).toHaveBeenCalledWith("ws://localhost:8080/ws/voice");
+	});
 });

--- a/frontend/src/hooks/useVoice.ts
+++ b/frontend/src/hooks/useVoice.ts
@@ -23,10 +23,31 @@ interface UseVoiceOptions {
 	readonly wsUrl?: string;
 	/** 音声チャンクの送信間隔 (ms) */
 	readonly chunkIntervalMs?: number;
+	/**
+	 * WebSocket 認証用 API キー。
+	 * ブラウザの WebSocket ハンドシェイクは Authorization ヘッダーを設定できないため、
+	 * access_token クエリパラメータとして送信する（デフォルトは VITE_POS_VOICE_API_KEY）。
+	 */
+	readonly apiKey?: string;
 }
 
 const DEFAULT_WS_URL = "ws://localhost:8080/ws/voice";
 const DEFAULT_CHUNK_INTERVAL_MS = 250;
+
+/** ビルド時に注入される API キーを取得する（未設定なら空文字列） */
+function getConfiguredApiKey(): string {
+	const key = import.meta.env.VITE_POS_VOICE_API_KEY;
+	return typeof key === "string" ? key : "";
+}
+
+/** WebSocket URL に access_token クエリパラメータを付与する（apiKey が空なら変更しない） */
+function buildWsUrl(baseUrl: string, apiKey: string): string {
+	if (!apiKey) {
+		return baseUrl;
+	}
+	const separator = baseUrl.includes("?") ? "&" : "?";
+	return `${baseUrl}${separator}access_token=${encodeURIComponent(apiKey)}`;
+}
 
 /**
  * 音声入力・WebSocket送信・認識結果受信を管理するフック.
@@ -37,7 +58,11 @@ const DEFAULT_CHUNK_INTERVAL_MS = 250;
  * 音声データはメモリ上のストリーム処理のみで、ファイル保存しない。
  */
 export function useVoice(options: UseVoiceOptions = {}): UseVoiceReturn {
-	const { wsUrl = DEFAULT_WS_URL, chunkIntervalMs = DEFAULT_CHUNK_INTERVAL_MS } = options;
+	const {
+		wsUrl = DEFAULT_WS_URL,
+		chunkIntervalMs = DEFAULT_CHUNK_INTERVAL_MS,
+		apiKey = getConfiguredApiKey(),
+	} = options;
 
 	const [state, setState] = useState<VoiceState>("idle");
 	const [result, setResult] = useState<RecognitionResult | null>(null);
@@ -95,7 +120,7 @@ export function useVoice(options: UseVoiceOptions = {}): UseVoiceReturn {
 			});
 			streamRef.current = mediaStream;
 
-			const ws = new WebSocket(wsUrl);
+			const ws = new WebSocket(buildWsUrl(wsUrl, apiKey));
 			ws.binaryType = "arraybuffer";
 			wsRef.current = ws;
 
@@ -152,7 +177,7 @@ export function useVoice(options: UseVoiceOptions = {}): UseVoiceReturn {
 			setState("error");
 			cleanup();
 		}
-	}, [wsUrl, chunkIntervalMs, cleanup, state]);
+	}, [wsUrl, apiKey, chunkIntervalMs, cleanup, state]);
 
 	const stopListening = useCallback(() => {
 		cleanup();

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+	/** WebSocket ハンドシェイク認証に使う API キー（ビルド時に注入） */
+	readonly VITE_POS_VOICE_API_KEY?: string;
+}
+
+interface ImportMeta {
+	readonly env: ImportMetaEnv;
+}

--- a/voice-engine/src/pos_voice_concierge/query_service.py
+++ b/voice-engine/src/pos_voice_concierge/query_service.py
@@ -5,10 +5,13 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
+
+import psycopg
 
 from pos_voice_concierge.generated import query_service_pb2, query_service_pb2_grpc
 from pos_voice_concierge.intent_classifier import Intent, classify
@@ -37,6 +40,29 @@ _PERIOD_MAP: dict[str, str] = {
     "this_month": "今月",
     "last_month": "先月",
 }
+
+# トップN件数の有効範囲。負数・ゼロ・過大値がそのまま DB の LIMIT に渡るのを防ぐ。
+_DEFAULT_TOP_N = 5
+_MIN_TOP_N = 1
+_MAX_TOP_N = 100
+
+
+def _parse_top_n(value: str) -> int:
+    """top_n スロット文字列を有効範囲 [1, 100] のトップN件数に変換する.
+
+    数値化できない値はデフォルト（5）にフォールバックする。
+
+    Args:
+        value: top_n スロットの文字列表現
+
+    Returns:
+        1〜100 に丸めたトップN件数
+    """
+    try:
+        parsed = int(value)
+    except (ValueError, TypeError):
+        return _DEFAULT_TOP_N
+    return max(_MIN_TOP_N, min(parsed, _MAX_TOP_N))
 
 
 def _resolve_period(period_key: str) -> tuple[datetime, datetime]:
@@ -199,8 +225,6 @@ class QueryServiceServicer(query_service_pb2_grpc.QueryServiceServicer):
         else:
             json_data = self._matcher.export_aliases_json()
 
-        import json  # noqa: PLC0415
-
         count = len(json.loads(json_data))
 
         return query_service_pb2.ExportAliasesResponse(
@@ -233,12 +257,20 @@ class QueryServiceServicer(query_service_pb2_grpc.QueryServiceServicer):
                 success=True,
                 message=f"{imported}件のエイリアスをインポートしました。",
             )
-        except Exception as e:
-            logger.exception("辞書インポートエラー")
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+            # 詳細（内部構造・入力内容）はクライアントに返さず、サーバーログにのみ記録する。
+            logger.exception("辞書インポートエラー: 入力データが不正")
             return query_service_pb2.ImportAliasesResponse(
                 imported_count=0,
                 success=False,
-                message=f"インポートに失敗しました: {e}",
+                message="インポートに失敗しました。入力データの形式を確認してください。",
+            )
+        except psycopg.Error:
+            logger.exception("辞書インポートエラー: データベース処理に失敗")
+            return query_service_pb2.ImportAliasesResponse(
+                imported_count=0,
+                success=False,
+                message="インポートに失敗しました。しばらくしてから再度お試しください。",
             )
 
     def _handle_sales_inquiry(
@@ -376,7 +408,7 @@ class QueryServiceServicer(query_service_pb2_grpc.QueryServiceServicer):
         )
 
         period_key = "today"
-        requested_n = 5
+        requested_n = _DEFAULT_TOP_N
 
         for slot in slots:
             if not isinstance(slot, SlotValue):
@@ -384,7 +416,7 @@ class QueryServiceServicer(query_service_pb2_grpc.QueryServiceServicer):
             if slot.name == "date_range":
                 period_key = slot.value
             elif slot.name == "top_n":
-                requested_n = int(slot.value)
+                requested_n = _parse_top_n(slot.value)
 
         period_label = _PERIOD_MAP.get(period_key, "今日")
         from_dt, to_dt = _resolve_period(period_key)

--- a/voice-engine/tests/test_query_service.py
+++ b/voice-engine/tests/test_query_service.py
@@ -17,7 +17,7 @@ from pos_voice_concierge.product_repository import (
 from pos_voice_concierge.product_repository import (
     TopProductEntry as RepoTopProductEntry,
 )
-from pos_voice_concierge.query_service import QueryServiceServicer
+from pos_voice_concierge.query_service import QueryServiceServicer, _parse_top_n
 
 
 class FakeServicerContext:
@@ -292,6 +292,68 @@ class TestImportAliases:
         request = query_service_pb2.ImportAliasesRequest(json_data="invalid json")
         response = servicer.ImportAliases(request, context)
         assert not response.success
+
+    def test_import_invalid_json_returns_generic_message(self, servicer, context):
+        """不正JSONのインポート失敗時、例外詳細を漏らさず汎用メッセージを返す（#37）."""
+        request = query_service_pb2.ImportAliasesRequest(json_data="{not valid")
+        response = servicer.ImportAliases(request, context)
+        assert not response.success
+        assert response.imported_count == 0
+        assert response.message == "インポートに失敗しました。入力データの形式を確認してください。"
+
+    def test_import_missing_field_returns_generic_message(self, servicer, context):
+        """必須フィールド欠落時も内部例外（KeyError等）を漏らさない（#37）."""
+        request = query_service_pb2.ImportAliasesRequest(json_data='[{"alias": "コーラ"}]')
+        response = servicer.ImportAliases(request, context)
+        assert not response.success
+        assert "失敗しました" in response.message
+        assert "KeyError" not in response.message
+        assert "product_name" not in response.message
+
+
+class TestParseTopN:
+    """トップN件数のバリデーション（#28）."""
+
+    def test_valid_value_passes_through(self):
+        assert _parse_top_n("50") == 50
+
+    def test_zero_is_clamped_to_min(self):
+        assert _parse_top_n("0") == 1
+
+    def test_negative_is_clamped_to_min(self):
+        assert _parse_top_n("-5") == 1
+
+    def test_oversized_is_clamped_to_max(self):
+        assert _parse_top_n("999") == 100
+
+    def test_non_numeric_falls_back_to_default(self):
+        assert _parse_top_n("abc") == 5
+
+
+class TestTopProductsValidation:
+    """トップN件数がリポジトリに渡る前にクランプされることの検証（#28）."""
+
+    def test_oversized_n_clamped_before_query(
+        self,
+        servicer_with_repo,
+        context,
+        mock_repository,
+    ):
+        request = query_service_pb2.QueryRequest(text="売上トップ999を教えて")
+        servicer_with_repo.ExecuteQuery(request, context)
+        call_args = mock_repository.top_products_between.call_args
+        assert call_args.args[2] == 100
+
+    def test_zero_n_clamped_before_query(
+        self,
+        servicer_with_repo,
+        context,
+        mock_repository,
+    ):
+        request = query_service_pb2.QueryRequest(text="売上トップ0を教えて")
+        servicer_with_repo.ExecuteQuery(request, context)
+        call_args = mock_repository.top_products_between.call_args
+        assert call_args.args[2] == 1
 
 
 class TestE2EQueryFlow:


### PR DESCRIPTION
## 概要
セキュリティ関連の4件を修正。

fixes #25, fixes #31, fixes #28, fixes #37

## 変更内容

### #25 WebSocket /ws/voice が認証フリー
- `application.properties` に `quarkus.http.auth.permission.ws`（`/ws/*` → authenticated）を追加。WebSocket ハンドシェイク（HTTP Upgrade）を既存の Quarkus HTTP セキュリティ層で保護。
- `ApiKeyAuthMechanism.resolveApiKey` を拡張: 全パスで `Authorization: Bearer` ヘッダーを優先し、`/ws/` 配下に限り `access_token` クエリパラメータをフォールバック許可（ブラウザ WebSocket はヘッダー設定不可のため）。
- フロントエンド `useVoice` がビルド時注入の `VITE_POS_VOICE_API_KEY` を `?access_token=` として付与。
- 設計判断と TLS/ログのリスク緩和策を **ADR-0003** に記録。

### #31 DB接続に sslmode=require 無し
- 本番/開発プロファイルで `sslmode=require`（`DATABASE_SSL_MODE` で上書き可）。test(H2) には付与しない。
- `.env.example` に `DATABASE_SSL_MODE` 追記。

### #28 requested_n バリデーションなし
- Python `_parse_top_n` と Kotlin `getTopProducts` で件数を `[1, 100]` にクランプ。負数・ゼロ・過大値が DB の `LIMIT` に渡らない。

### #37 例外メッセージのクライアント漏洩
- 辞書インポート失敗時、`except Exception as e` の `{e}` 露出をやめ、具体的な例外型（`json.JSONDecodeError`/`KeyError`/`psycopg.Error` 等）を捕捉して汎用メッセージを返却、詳細はサーバーログのみに記録。

## テスト
- backend: `ApiKeyAuthMechanismTest`（resolveApiKey 7ケース）、`QueryResourceTest`（WS未認証→401、REST の access_token 無視、limit クランプ）、`DatabaseSslConfigTest`（sslmode 既定 require）
- voice-engine: `_parse_top_n` 5ケース、top-products クランプ、インポート汎用メッセージ
- frontend: `useVoice` の access_token 付与/非付与
- ローカル検証: backend `./gradlew build` 成功、voice-engine 全テスト+ruff pass、frontend oxlint/biome/tsc/vitest pass