### PR TITLE
バグ+機能修正: itemCount実データ・日付スロット・型安全クエリ・Whisperモデル検証

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ DATABASE_PASSWORD=
 DATABASE_SSL_MODE=require
 
 # === Voice Engine ===
+# Whisper モデルサイズ: tiny / base / small / medium / large（.en 系・large-v2/v3・turbo も可）
+# 未知の値を指定した場合は警告を出して base にフォールバックする
 WHISPER_MODEL=base
 VOICE_ENGINE_HOST=localhost
 VOICE_ENGINE_PORT=50051

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,7 @@ jobs:
       - name: Test
         working-directory: frontend
         run: npx vitest run
+
+      - name: Build
+        working-directory: frontend
+        run: npm run build

--- a/backend/src/main/kotlin/com/akaitigo/posvoice/query/QueryResource.kt
+++ b/backend/src/main/kotlin/com/akaitigo/posvoice/query/QueryResource.kt
@@ -62,11 +62,12 @@ class QueryResource {
 
         if (product != null) {
             val amount = salesRepository.productSalesBetween(product, from, to)
+            val itemCount = salesRepository.countProductSalesBetween(product, from, to)
             return Response.ok(
                 SalesResponse(
                     totalAmount = amount,
                     periodLabel = label,
-                    itemCount = 0,
+                    itemCount = itemCount.toInt(),
                     productName = product,
                 ),
             ).build()

--- a/backend/src/main/kotlin/com/akaitigo/posvoice/query/SalesRepository.kt
+++ b/backend/src/main/kotlin/com/akaitigo/posvoice/query/SalesRepository.kt
@@ -3,6 +3,7 @@ package com.akaitigo.posvoice.query
 import io.quarkus.hibernate.orm.panache.kotlin.PanacheRepositoryBase
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.persistence.EntityManager
+import jakarta.persistence.Tuple
 import jakarta.inject.Inject
 import java.time.OffsetDateTime
 
@@ -35,13 +36,15 @@ class SalesRepository : PanacheRepositoryBase<SalesEntity, Long> {
 
     /**
      * 指定期間の商品別売上トップNを取得する.
+     *
+     * 型安全な [Tuple] クエリを使用し、非チェックキャストを排除する。
+     * 集計値は DB 実装差（Long/BigInteger 等）を吸収するため [Number] として取り出す。
      */
     fun topProductsBetween(
         from: OffsetDateTime,
         to: OffsetDateTime,
         limit: Int,
     ): List<TopProductResult> {
-        @Suppress("UNCHECKED_CAST")
         val results = em.createQuery(
             """
             SELECT p.name, SUM(s.totalPrice), SUM(s.quantity)
@@ -50,18 +53,19 @@ class SalesRepository : PanacheRepositoryBase<SalesEntity, Long> {
             GROUP BY p.name
             ORDER BY SUM(s.totalPrice) DESC
             """.trimIndent(),
+            Tuple::class.java,
         )
             .setParameter("from", from)
             .setParameter("to", to)
             .setMaxResults(limit)
-            .resultList as List<Array<Any>>
+            .resultList
 
-        return results.mapIndexed { index, row ->
+        return results.mapIndexed { index, tuple ->
             TopProductResult(
                 rank = index + 1,
-                productName = row[0] as String,
-                totalAmount = (row[1] as Number).toLong(),
-                quantitySold = (row[2] as Number).toInt(),
+                productName = tuple.get(0, String::class.java),
+                totalAmount = tuple.get(1, Number::class.java).toLong(),
+                quantitySold = tuple.get(2, Number::class.java).toInt(),
             )
         }
     }
@@ -87,6 +91,28 @@ class SalesRepository : PanacheRepositoryBase<SalesEntity, Long> {
             .setParameter("to", to)
             .singleResult
         return result ?: 0L
+    }
+
+    /**
+     * 指定商品の期間別売上件数（取引数）を取得する.
+     */
+    fun countProductSalesBetween(
+        productName: String,
+        from: OffsetDateTime,
+        to: OffsetDateTime,
+    ): Long {
+        return em.createQuery(
+            """
+            SELECT COUNT(s)
+            FROM SalesEntity s JOIN ProductEntity p ON s.productId = p.id
+            WHERE p.name = :name AND s.soldAt >= :from AND s.soldAt < :to
+            """.trimIndent(),
+            Long::class.java,
+        )
+            .setParameter("name", productName)
+            .setParameter("from", from)
+            .setParameter("to", to)
+            .singleResult
     }
 }
 

--- a/backend/src/test/kotlin/com/akaitigo/posvoice/query/SalesRepositoryTest.kt
+++ b/backend/src/test/kotlin/com/akaitigo/posvoice/query/SalesRepositoryTest.kt
@@ -1,0 +1,107 @@
+package com.akaitigo.posvoice.query
+
+import io.quarkus.test.TestTransaction
+import io.quarkus.test.junit.QuarkusTest
+import jakarta.inject.Inject
+import jakarta.persistence.EntityManager
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+/**
+ * [SalesRepository] の実データテスト（H2）.
+ *
+ * Issue #26（商品別 itemCount）と Issue #29（型安全な topProductsBetween）を、
+ * 実際に商品・売上行を投入して検証する。各テストは [TestTransaction] でロールバックし隔離する。
+ */
+@QuarkusTest
+class SalesRepositoryTest {
+
+    @Inject
+    lateinit var salesRepository: SalesRepository
+
+    @Inject
+    lateinit var em: EntityManager
+
+    private val from = OffsetDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
+    private val to = OffsetDateTime.of(2026, 1, 2, 0, 0, 0, 0, ZoneOffset.UTC)
+    private val soldAt = OffsetDateTime.of(2026, 1, 1, 10, 0, 0, 0, ZoneOffset.UTC)
+
+    @Test
+    @TestTransaction
+    fun `countProductSalesBetween counts only matching product transactions`() {
+        seedData()
+
+        assertEquals(2L, salesRepository.countProductSalesBetween("コーラ", from, to))
+        assertEquals(1L, salesRepository.countProductSalesBetween("お茶", from, to))
+        assertEquals(0L, salesRepository.countProductSalesBetween("存在しない商品", from, to))
+    }
+
+    @Test
+    @TestTransaction
+    fun `productSalesBetween sums matching product totals`() {
+        seedData()
+
+        assertEquals(750L, salesRepository.productSalesBetween("コーラ", from, to))
+        assertEquals(130L, salesRepository.productSalesBetween("お茶", from, to))
+    }
+
+    @Test
+    @TestTransaction
+    fun `topProductsBetween returns type-safe ranked aggregates`() {
+        seedData()
+
+        val top = salesRepository.topProductsBetween(from, to, 5)
+
+        assertEquals(2, top.size)
+        // コーラ: 450 + 300 = 750（数量 3 + 2 = 5）, お茶: 130（数量 1）
+        assertEquals(1, top[0].rank)
+        assertEquals("コーラ", top[0].productName)
+        assertEquals(750L, top[0].totalAmount)
+        assertEquals(5, top[0].quantitySold)
+        assertEquals(2, top[1].rank)
+        assertEquals("お茶", top[1].productName)
+        assertEquals(130L, top[1].totalAmount)
+        assertEquals(1, top[1].quantitySold)
+    }
+
+    @Test
+    @TestTransaction
+    fun `topProductsBetween honors the limit`() {
+        seedData()
+
+        val top = salesRepository.topProductsBetween(from, to, 1)
+
+        assertEquals(1, top.size)
+        assertEquals("コーラ", top[0].productName)
+    }
+
+    private fun seedData() {
+        persistProduct("prod-cola", "コーラ", "4900000000001", 150)
+        persistProduct("prod-tea", "お茶", "4900000000002", 130)
+        persistSale("prod-cola", quantity = 3, unitPrice = 150, totalPrice = 450)
+        persistSale("prod-cola", quantity = 2, unitPrice = 150, totalPrice = 300)
+        persistSale("prod-tea", quantity = 1, unitPrice = 130, totalPrice = 130)
+        em.flush()
+    }
+
+    private fun persistProduct(id: String, name: String, barcode: String, price: Int) {
+        val product = ProductEntity()
+        product.id = id
+        product.name = name
+        product.barcode = barcode
+        product.price = price
+        em.persist(product)
+    }
+
+    private fun persistSale(productId: String, quantity: Int, unitPrice: Int, totalPrice: Int) {
+        val sale = SalesEntity()
+        sale.productId = productId
+        sale.quantity = quantity
+        sale.unitPrice = unitPrice
+        sale.totalPrice = totalPrice
+        sale.soldAt = soldAt
+        em.persist(sale)
+    }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ja">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>POS Voice Concierge</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/src/main.tsx"></script>
+	</body>
+</html>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,14 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+
+const rootElement = document.getElementById("root");
+if (rootElement === null) {
+	throw new Error("ルート要素 #root が見つかりません");
+}
+
+createRoot(rootElement).render(
+	<StrictMode>
+		<App />
+	</StrictMode>,
+);

--- a/voice-engine/src/pos_voice_concierge/query_service.py
+++ b/voice-engine/src/pos_voice_concierge/query_service.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
@@ -105,6 +106,90 @@ def _resolve_period(period_key: str) -> tuple[datetime, datetime]:
         to_dt = today + timedelta(days=1)
 
     return (from_dt.astimezone(UTC), to_dt.astimezone(UTC))
+
+
+# 明示的な期間指定スロット（"M/D" 形式）
+_EXPLICIT_DATE_RE = re.compile(r"^(\d{1,2})/(\d{1,2})$")
+# 日付表現（商品名として誤抽出された期間テキストの判定用）。
+# 「からあげ」等の誤検出を避けるため、数字+月/日 のみを対象とする。
+_DATE_EXPRESSION_RE = re.compile(r"\d+月|\d+日")
+
+
+def _resolve_explicit_range(
+    start_value: str,
+    end_value: str,
+) -> tuple[datetime, datetime, str] | None:
+    """明示的な期間指定（"M/D" 形式）を UTC の (from, to, label) に変換する.
+
+    年は現在の JST 年を使用する。end_value は当日を含めるため終端を +1 日する。
+
+    Args:
+        start_value: 開始日（"M/D"）
+        end_value: 終了日（"M/D"）
+
+    Returns:
+        (from_dt, to_dt, label)。パース不能または from >= to の場合は None。
+    """
+    start_match = _EXPLICIT_DATE_RE.match(start_value)
+    end_match = _EXPLICIT_DATE_RE.match(end_value)
+    if start_match is None or end_match is None:
+        return None
+
+    year = datetime.now(tz=_JST).year
+    try:
+        from_dt = datetime(year, int(start_match.group(1)), int(start_match.group(2)), tzinfo=_JST)
+        end_day = datetime(year, int(end_match.group(1)), int(end_match.group(2)), tzinfo=_JST)
+    except ValueError:
+        return None
+
+    to_dt = end_day + timedelta(days=1)
+    if from_dt >= to_dt:
+        return None
+
+    label = f"{start_value}〜{end_value}"
+    return (from_dt.astimezone(UTC), to_dt.astimezone(UTC), label)
+
+
+def _resolve_range_from_slots(
+    period_key: str,
+    start_date: str | None,
+    end_date: str | None,
+) -> tuple[datetime, datetime, str]:
+    """スロットから (from, to, label) を解決する.
+
+    明示的な期間指定（start_date/end_date）が有効ならそれを優先し、
+    無ければ期間キー（today/last_month 等）から解決する。
+
+    Args:
+        period_key: 期間キー
+        start_date: 明示的な開始日（"M/D"）または None
+        end_date: 明示的な終了日（"M/D"）または None
+
+    Returns:
+        (from_dt, to_dt, label)
+    """
+    if start_date is not None and end_date is not None:
+        explicit = _resolve_explicit_range(start_date, end_date)
+        if explicit is not None:
+            return explicit
+
+    period_label = _PERIOD_MAP.get(period_key, "今日")
+    from_dt, to_dt = _resolve_period(period_key)
+    return (from_dt, to_dt, period_label)
+
+
+def _looks_like_date_expression(text: str) -> bool:
+    """テキストが日付表現（「3月」「15日」「から」）を含むかどうかを返す.
+
+    明示的な期間指定時に、日付レンジが商品名として誤抽出された場合の除外に使う。
+
+    Args:
+        text: 判定対象テキスト
+
+    Returns:
+        日付表現を含む場合 True
+    """
+    return _DATE_EXPRESSION_RE.search(text) is not None
 
 
 class QueryServiceServicer(query_service_pb2_grpc.QueryServiceServicer):
@@ -290,14 +375,30 @@ class QueryServiceServicer(query_service_pb2_grpc.QueryServiceServicer):
 
         period_key = "today"
         product_name: str | None = None
+        start_date: str | None = None
+        end_date: str | None = None
         for slot in slots:
-            if isinstance(slot, SlotValue) and slot.name == "date_range":
+            if not isinstance(slot, SlotValue):
+                continue
+            if slot.name == "date_range":
                 period_key = slot.value
-            elif isinstance(slot, SlotValue) and slot.name == "product_name":
+            elif slot.name == "product_name":
                 product_name = slot.value
+            elif slot.name == "start_date":
+                start_date = slot.value
+            elif slot.name == "end_date":
+                end_date = slot.value
 
-        period_label = _PERIOD_MAP.get(period_key, "今日")
-        from_dt, to_dt = _resolve_period(period_key)
+        from_dt, to_dt, period_label = _resolve_range_from_slots(period_key, start_date, end_date)
+
+        # 明示的な期間指定時、日付レンジが商品名として誤抽出された場合は無視する
+        if (
+            start_date is not None
+            and end_date is not None
+            and product_name is not None
+            and _looks_like_date_expression(product_name)
+        ):
+            product_name = None
 
         total_amount = 0
         item_count = 0
@@ -409,6 +510,8 @@ class QueryServiceServicer(query_service_pb2_grpc.QueryServiceServicer):
 
         period_key = "today"
         requested_n = _DEFAULT_TOP_N
+        start_date: str | None = None
+        end_date: str | None = None
 
         for slot in slots:
             if not isinstance(slot, SlotValue):
@@ -417,9 +520,12 @@ class QueryServiceServicer(query_service_pb2_grpc.QueryServiceServicer):
                 period_key = slot.value
             elif slot.name == "top_n":
                 requested_n = _parse_top_n(slot.value)
+            elif slot.name == "start_date":
+                start_date = slot.value
+            elif slot.name == "end_date":
+                end_date = slot.value
 
-        period_label = _PERIOD_MAP.get(period_key, "今日")
-        from_dt, to_dt = _resolve_period(period_key)
+        from_dt, to_dt, period_label = _resolve_range_from_slots(period_key, start_date, end_date)
 
         entries: list[ResponseTopProductEntry] = []
         if self._repository is not None:

--- a/voice-engine/src/pos_voice_concierge/server_main.py
+++ b/voice-engine/src/pos_voice_concierge/server_main.py
@@ -10,7 +10,7 @@ from threading import Event
 
 from pos_voice_concierge.fuzzy_matcher import FuzzyMatcher
 from pos_voice_concierge.grpc_server import DEFAULT_PORT, create_server
-from pos_voice_concierge.whisper_engine import WhisperEngine
+from pos_voice_concierge.whisper_engine import WhisperEngine, resolve_model_name
 
 logging.basicConfig(
     level=logging.INFO,
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 def main() -> None:
     """サーバーを起動する."""
     port = int(os.environ.get("VOICE_ENGINE_PORT", str(DEFAULT_PORT)))
-    model_name = os.environ.get("WHISPER_MODEL", "base")
+    model_name = resolve_model_name()
 
     engine = WhisperEngine(model_name=model_name)
     matcher = FuzzyMatcher(threshold=80.0)

--- a/voice-engine/src/pos_voice_concierge/whisper_engine.py
+++ b/voice-engine/src/pos_voice_concierge/whisper_engine.py
@@ -7,11 +7,63 @@ from __future__ import annotations
 
 import io
 import logging
-from typing import Protocol
+import os
+from typing import TYPE_CHECKING, Protocol
 
 import numpy as np
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
 logger = logging.getLogger(__name__)
+
+DEFAULT_WHISPER_MODEL = "base"
+
+# Whisper が提供する既知のモデル名（tiny〜large と turbo、英語専用 .en 系を含む）
+KNOWN_WHISPER_MODELS: frozenset[str] = frozenset(
+    {
+        "tiny",
+        "tiny.en",
+        "base",
+        "base.en",
+        "small",
+        "small.en",
+        "medium",
+        "medium.en",
+        "large",
+        "large-v1",
+        "large-v2",
+        "large-v3",
+        "turbo",
+    },
+)
+
+
+def resolve_model_name(env: Mapping[str, str] | None = None) -> str:
+    """環境変数 WHISPER_MODEL から使用する Whisper モデル名を解決する.
+
+    未設定時は既定（base）。既知のモデル名でない場合は警告を出し既定に戻す。
+    これによりタイプミス等の不正なモデル名でモデルロードが失敗する前に検知できる。
+
+    Args:
+        env: 環境変数マッピング（省略時は os.environ）
+
+    Returns:
+        使用する Whisper モデル名
+    """
+    source = os.environ if env is None else env
+    raw = source.get("WHISPER_MODEL", DEFAULT_WHISPER_MODEL).strip()
+    if not raw:
+        return DEFAULT_WHISPER_MODEL
+    if raw not in KNOWN_WHISPER_MODELS:
+        logger.warning(
+            "未知の WHISPER_MODEL '%s' が指定されました。既定の '%s' を使用します。許容値: %s",
+            raw,
+            DEFAULT_WHISPER_MODEL,
+            ", ".join(sorted(KNOWN_WHISPER_MODELS)),
+        )
+        return DEFAULT_WHISPER_MODEL
+    return raw
 
 
 class TranscriptionEngine(Protocol):

--- a/voice-engine/tests/test_query_service.py
+++ b/voice-engine/tests/test_query_service.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
+from zoneinfo import ZoneInfo
 
 import grpc  # noqa: TC002
 import pytest
@@ -17,7 +19,14 @@ from pos_voice_concierge.product_repository import (
 from pos_voice_concierge.product_repository import (
     TopProductEntry as RepoTopProductEntry,
 )
-from pos_voice_concierge.query_service import QueryServiceServicer, _parse_top_n
+from pos_voice_concierge.query_service import (
+    QueryServiceServicer,
+    _looks_like_date_expression,
+    _parse_top_n,
+    _resolve_explicit_range,
+)
+
+_JST = ZoneInfo("Asia/Tokyo")
 
 
 class FakeServicerContext:
@@ -446,3 +455,77 @@ class TestE2EQueryFlow:
         assert response.intent == "inventory_inquiry"
         assert response.data.HasField("inventory")
         assert response.data.inventory.stock_quantity == 24
+
+
+class TestResolveExplicitRange:
+    """明示的な期間指定パーサーの単体テスト（#27）."""
+
+    def test_valid_range(self):
+        result = _resolve_explicit_range("3/15", "3/20")
+        assert result is not None
+        _, _, label = result
+        assert label == "3/15〜3/20"
+
+    def test_end_is_inclusive(self):
+        result = _resolve_explicit_range("3/15", "3/20")
+        assert result is not None
+        from_dt, to_dt, _ = result
+        year = datetime.now(tz=_JST).year
+        assert from_dt == datetime(year, 3, 15, tzinfo=_JST).astimezone(UTC)
+        # 終了日を含めるため 3/21 00:00 が排他的終端
+        assert to_dt == datetime(year, 3, 21, tzinfo=_JST).astimezone(UTC)
+
+    def test_invalid_format_returns_none(self):
+        assert _resolve_explicit_range("march", "20") is None
+
+    def test_reversed_range_returns_none(self):
+        assert _resolve_explicit_range("3/20", "3/15") is None
+
+    def test_invalid_calendar_date_returns_none(self):
+        assert _resolve_explicit_range("13/40", "13/41") is None
+
+    def test_looks_like_date_expression(self):
+        assert _looks_like_date_expression("3月15日から3月20日") is True
+        assert _looks_like_date_expression("からあげクン") is False
+        assert _looks_like_date_expression("コーラ") is False
+
+
+class TestExplicitDateRangeHandling:
+    """query_service が start_date/end_date スロットを反映することの検証（#27）."""
+
+    def test_sales_inquiry_applies_explicit_range(
+        self,
+        servicer_with_repo,
+        context,
+        mock_repository,
+    ):
+        request = query_service_pb2.QueryRequest(text="3月15日から3月20日の売上は？")
+        response = servicer_with_repo.ExecuteQuery(request, context)
+
+        assert response.intent == "sales_inquiry"
+        # 期間レンジ指定時は商品指定なしの total_sales_between が呼ばれる
+        mock_repository.total_sales_between.assert_called_once()
+        mock_repository.product_sales_between.assert_not_called()
+
+        from_dt, to_dt = mock_repository.total_sales_between.call_args.args
+        year = datetime.now(tz=_JST).year
+        assert from_dt == datetime(year, 3, 15, tzinfo=_JST).astimezone(UTC)
+        assert to_dt == datetime(year, 3, 21, tzinfo=_JST).astimezone(UTC)
+        assert response.data.sales.period_label == "3/15〜3/20"
+
+    def test_top_products_applies_explicit_range(
+        self,
+        servicer_with_repo,
+        context,
+        mock_repository,
+    ):
+        request = query_service_pb2.QueryRequest(text="3月15日から3月20日の売上トップ3は？")
+        response = servicer_with_repo.ExecuteQuery(request, context)
+
+        assert response.intent == "top_products"
+        from_dt, to_dt, limit = mock_repository.top_products_between.call_args.args
+        year = datetime.now(tz=_JST).year
+        assert from_dt == datetime(year, 3, 15, tzinfo=_JST).astimezone(UTC)
+        assert to_dt == datetime(year, 3, 21, tzinfo=_JST).astimezone(UTC)
+        assert limit == 3
+        assert response.data.top_products.period_label == "3/15〜3/20"

--- a/voice-engine/tests/test_whisper_engine.py
+++ b/voice-engine/tests/test_whisper_engine.py
@@ -8,7 +8,12 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 
 from pos_voice_concierge.audio_converter import create_wav_from_pcm
-from pos_voice_concierge.whisper_engine import TranscriptionResult, WhisperEngine
+from pos_voice_concierge.whisper_engine import (
+    DEFAULT_WHISPER_MODEL,
+    TranscriptionResult,
+    WhisperEngine,
+    resolve_model_name,
+)
 
 
 class TestWhisperEngine:
@@ -64,6 +69,28 @@ class TestWhisperEngine:
     def test_calculate_average_confidence_empty(self) -> None:
         confidence = WhisperEngine._calculate_average_confidence([])
         assert confidence == 0.0
+
+
+class TestResolveModelName:
+    """WHISPER_MODEL 環境変数からのモデル名解決（#34）."""
+
+    def test_default_when_unset(self):
+        assert resolve_model_name({}) == "base"
+
+    def test_reads_env_value(self):
+        assert resolve_model_name({"WHISPER_MODEL": "small"}) == "small"
+
+    def test_accepts_versioned_large(self):
+        assert resolve_model_name({"WHISPER_MODEL": "large-v3"}) == "large-v3"
+
+    def test_strips_whitespace(self):
+        assert resolve_model_name({"WHISPER_MODEL": "  medium  "}) == "medium"
+
+    def test_unknown_falls_back_to_default(self):
+        assert resolve_model_name({"WHISPER_MODEL": "gigantic"}) == DEFAULT_WHISPER_MODEL
+
+    def test_empty_falls_back_to_default(self):
+        assert resolve_model_name({"WHISPER_MODEL": "   "}) == "base"
 
 
 def _create_test_wav(


### PR DESCRIPTION
## 概要
バグ2件・機能2件・既知のビルド不備を修正。

fixes #26, fixes #27, fixes #29, fixes #34

## 変更内容

### #26 商品別売上の itemCount=0 ハードコード
- `SalesRepository.countProductSalesBetween` を追加し、`QueryResource` の商品別売上で実際の取引件数を返すよう修正。

### #27 日付スロット(start_date/end_date)が未処理
- `intent_classifier` が抽出する `start_date`/`end_date`（"M/D"）を `query_service` で解決するヘルパー（`_resolve_explicit_range` / `_resolve_range_from_slots`）を追加。売上照会・トップ商品の両方で明示的期間を反映。
- 期間レンジが商品名として誤抽出された場合は除外（`_looks_like_date_expression`、「からあげ」等の誤検出を避け数字+月/日 のみ判定）。

### #29 topProductsBetween の UNCHECKED_CAST
- `@Suppress("UNCHECKED_CAST")` と `resultList as List<Array<Any>>` を廃止し、型安全な `Tuple` クエリに変更。集計値は DB 実装差を吸収するため `Number` として取得。

### #34 Whisper model size のハードコード
- `resolve_model_name` を追加。`WHISPER_MODEL` を検証し、未知の値は警告を出して `base` にフォールバック。`server_main` に配線し `.env.example` に許容値を明記。

### frontend build 不備（既知の既存問題）
- `frontend/index.html` と `src/main.tsx` が未コミットで `vite build` が `UNRESOLVED_ENTRY` で失敗していた。標準的な Vite + React の entry を追加し `npm run build` が通ることを確認。
- CI の Frontend ジョブに `Build` ステップを追加し、今後ビルド不備を検知できるようにした。

## テスト
- backend: `SalesRepositoryTest`（@TestTransaction で実データ投入し countProductSalesBetween / productSalesBetween / 型安全な topProductsBetween のランキング・limit を検証）
- voice-engine: `_resolve_explicit_range`/`_looks_like_date_expression` 単体、売上・トップ商品の明示的期間反映、`resolve_model_name` の既定/env/未知値フォールバック
- frontend: `npm run build` 成功（dist 生成）
- ローカル検証: backend `./gradlew build` 成功（SalesRepositoryTest 4/4）、voice-engine 189テスト+ruff pass、frontend build/oxlint/biome/tsc/vitest pass