### PR TITLE
品質+テスト+docs: except具体化・mypy型チェック・StreamRecognizeテスト・gRPC ADR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
         working-directory: voice-engine
         run: .venv/bin/ruff check .
 
+      - name: Type check
+        working-directory: voice-engine
+        run: .venv/bin/mypy
+
       - name: Test
         working-directory: voice-engine
         run: .venv/bin/pytest

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test-voice:
 	cd voice-engine && $(CURDIR)/$(VOICE_VENV)/pytest
 
 lint-voice:
-	cd voice-engine && $(CURDIR)/$(VOICE_VENV)/ruff check .
+	cd voice-engine && $(CURDIR)/$(VOICE_VENV)/ruff check . && $(CURDIR)/$(VOICE_VENV)/mypy
 
 format-voice:
 	cd voice-engine && $(CURDIR)/$(VOICE_VENV)/ruff format . && $(CURDIR)/$(VOICE_VENV)/ruff check --fix .

--- a/docs/adr/0004-grpc-insecure-port.md
+++ b/docs/adr/0004-grpc-insecure-port.md
@@ -1,0 +1,42 @@
+# ADR-0004: Backend ↔ Voice Engine 間 gRPC の insecure port 使用
+
+## ステータス
+
+Accepted
+
+## コンテキスト
+
+Backend（Quarkus）と Voice Engine（Python）間は gRPC 双方向ストリーミングで通信する（ADR-0001）。現状の実装は平文（insecure）で接続している:
+
+- Voice Engine 側: `grpc_server.py` の `server.add_insecure_port(f"[::]:{port}")`
+- Backend 側: `quarkus.grpc.clients.voice-engine.host/port`（TLS 設定なし）
+
+CLAUDE.md には「全通信 TLS 1.2+ 必須」とあり、この設計判断が ADR に記録されていなかった（Issue #30）。本 ADR で現状の設計判断・リスク・本番移行計画を明文化する。
+
+## 決定
+
+MVP 段階では、Backend ↔ Voice Engine 間の gRPC を **insecure port** で運用する。
+
+### 理由
+
+- Backend と Voice Engine は同一ホスト／同一プライベートネットワーク（例: Kubernetes の Pod 内 localhost、または同一 namespace 内サービス）での内部通信を前提とする。外部公開はしない。
+- mTLS 証明書の発行・ローテーション・配布は運用コストが高く、MVP のスコープ外。
+- 外部公開される通信（ブラウザ ↔ Backend の WebSocket）は別途 TLS（wss://）で保護する（ADR-0003）。TLS 必須ポリシーの主対象はこの外部境界である。
+
+### 本番移行時の対応
+
+内部ネットワークが信頼境界にならない構成（マルチテナント、ネットワーク分離が不十分な環境）へ移行する場合、以下を実施し本 ADR を更新する:
+
+1. Voice Engine 側を `server.add_secure_port` + `grpc.ssl_server_credentials`（サーバー証明書、必要に応じて mTLS のクライアント証明書検証）に切り替える。
+2. Backend 側 `quarkus.grpc.clients.voice-engine.ssl.*`（trust-store / key-store）で secure channel を構成する。
+3. 証明書は環境変数／シークレットマネージャで注入し、ローテーション手順を整備する。
+4. サービスメッシュ（例: Istio mTLS）で透過的に暗号化する選択肢も検討する。
+
+## リスクと緩和策
+
+- **リスク**: 内部ネットワークでの中間者攻撃（MITM）・盗聴。内部通信が平文のため、ネットワークに侵入した攻撃者は音声認識結果や集計データを傍受・改竄し得る。
+- **緩和策（MVP）**:
+  - gRPC ポートを外部に公開しない（内部ネットワーク／localhost バインドに限定）。
+  - ネットワークポリシー（例: Kubernetes NetworkPolicy）で Backend からのアクセスのみ許可する。
+  - 音声データはストリーミング処理のみでディスクに永続化しない（ADR-0001）ため、傍受されても保存リスクは限定的。
+- 上記が満たせない環境では、本番移行時の対応（mTLS 化）を必須とする。

--- a/voice-engine/pyproject.toml
+++ b/voice-engine/pyproject.toml
@@ -18,6 +18,7 @@ dev = [
     "pytest-cov>=7.1.0",
     "pytest-asyncio>=0.24",
     "ruff>=0.8",
+    "mypy>=1.13",
 ]
 
 [build-system]
@@ -123,6 +124,26 @@ max-branches = 12
 quote-style = "double"
 indent-style = "space"
 docstring-code-format = true
+
+# ==============================================================================
+# mypy
+# ==============================================================================
+[tool.mypy]
+python_version = "3.12"
+files = ["src"]
+mypy_path = "src"
+exclude = ['src/pos_voice_concierge/generated/.*']
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_unused_configs = true
+
+[[tool.mypy.overrides]]
+module = ["whisper", "grpc", "grpc.*", "pos_voice_concierge.generated.*"]
+ignore_missing_imports = true
 
 # ==============================================================================
 # pytest

--- a/voice-engine/src/pos_voice_concierge/product_repository.py
+++ b/voice-engine/src/pos_voice_concierge/product_repository.py
@@ -16,6 +16,44 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _as_int(value: object) -> int:
+    """DB カーソルから得た値（型は object）を int に変換する.
+
+    Args:
+        value: DB 行の値
+
+    Returns:
+        整数値
+
+    Raises:
+        TypeError: int に変換できない型の場合。
+    """
+    if isinstance(value, int):
+        return value
+    if isinstance(value, (str, float)):
+        return int(value)
+    msg = f"cannot convert {type(value).__name__} to int"
+    raise TypeError(msg)
+
+
+def _as_datetime(value: object) -> datetime:
+    """DB カーソルから得た値（型は object）を datetime に変換する.
+
+    Args:
+        value: DB 行の値
+
+    Returns:
+        datetime 値
+
+    Raises:
+        TypeError: datetime でない場合。
+    """
+    if isinstance(value, datetime):
+        return value
+    msg = f"expected datetime, got {type(value).__name__}"
+    raise TypeError(msg)
+
+
 @dataclass(frozen=True)
 class Product:
     """商品マスタエンティティ."""
@@ -86,7 +124,7 @@ class ProductRepository:
         with self._conn.cursor() as cur:
             cur.execute("SELECT id, name, barcode, price FROM products ORDER BY name")
             return [
-                Product(id=str(row[0]), name=str(row[1]), barcode=str(row[2]), price=int(row[3]))  # type: ignore[arg-type]
+                Product(id=str(row[0]), name=str(row[1]), barcode=str(row[2]), price=_as_int(row[3]))
                 for row in cur.fetchall()
             ]
 
@@ -107,7 +145,7 @@ class ProductRepository:
             row = cur.fetchone()
             if row is None:
                 return None
-            return Product(id=str(row[0]), name=str(row[1]), barcode=str(row[2]), price=int(row[3]))  # type: ignore[arg-type]
+            return Product(id=str(row[0]), name=str(row[1]), barcode=str(row[2]), price=_as_int(row[3]))
 
     def find_all_aliases(self) -> list[Alias]:
         """全表記ゆれエントリを取得する.
@@ -118,7 +156,7 @@ class ProductRepository:
         with self._conn.cursor() as cur:
             cur.execute("SELECT alias, product_name, created_at FROM aliases ORDER BY alias")
             return [
-                Alias(alias=str(row[0]), product_name=str(row[1]), created_at=row[2])  # type: ignore[arg-type]
+                Alias(alias=str(row[0]), product_name=str(row[1]), created_at=_as_datetime(row[2]))
                 for row in cur.fetchall()
             ]
 
@@ -246,8 +284,8 @@ class ProductRepository:
             if row is None:
                 return SalesResult(total_amount=0, item_count=0, period_label="")
             return SalesResult(
-                total_amount=int(row[0]),
-                item_count=int(row[1]),
+                total_amount=_as_int(row[0]),
+                item_count=_as_int(row[1]),
                 period_label="",
             )
 
@@ -281,8 +319,8 @@ class ProductRepository:
             if row is None:
                 return SalesResult(total_amount=0, item_count=0, period_label="")
             return SalesResult(
-                total_amount=int(row[0]),
-                item_count=int(row[1]),
+                total_amount=_as_int(row[0]),
+                item_count=_as_int(row[1]),
                 period_label="",
             )
 
@@ -310,7 +348,7 @@ class ProductRepository:
                 return None
             return InventoryResult(
                 product_name=str(row[0]),
-                stock_quantity=int(row[1]),
+                stock_quantity=_as_int(row[1]),
             )
 
     def top_products_between(
@@ -346,8 +384,8 @@ class ProductRepository:
                 TopProductEntry(
                     rank=idx + 1,
                     product_name=str(row[0]),
-                    total_amount=int(row[1]),
-                    quantity_sold=int(row[2]),
+                    total_amount=_as_int(row[1]),
+                    quantity_sold=_as_int(row[2]),
                 )
                 for idx, row in enumerate(cur.fetchall())
             ]

--- a/voice-engine/src/pos_voice_concierge/query_service.py
+++ b/voice-engine/src/pos_voice_concierge/query_service.py
@@ -415,7 +415,7 @@ class QueryServiceServicer(query_service_pb2_grpc.QueryServiceServicer):
                     result = self._repository.total_sales_between(from_dt, to_dt)
                 total_amount = result.total_amount
                 item_count = result.item_count
-            except Exception:
+            except psycopg.Error:
                 logger.exception("売上データ取得エラー")
 
         sales_data = SalesData(
@@ -470,7 +470,7 @@ class QueryServiceServicer(query_service_pb2_grpc.QueryServiceServicer):
                 inv_result = self._repository.find_stock_by_product_name(product_name)
                 if inv_result is not None:
                     stock_quantity = inv_result.stock_quantity
-            except Exception:
+            except psycopg.Error:
                 logger.exception("在庫データ取得エラー")
 
         inventory_data = InventoryData(
@@ -544,7 +544,7 @@ class QueryServiceServicer(query_service_pb2_grpc.QueryServiceServicer):
                     )
                     for e in db_entries
                 ]
-            except Exception:
+            except psycopg.Error:
                 logger.exception("トップ商品データ取得エラー")
 
         response_text = generate_top_products_response(entries, period_label)

--- a/voice-engine/src/pos_voice_concierge/server_main.py
+++ b/voice-engine/src/pos_voice_concierge/server_main.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import os
 import signal
-import sys
 from threading import Event
 
 from pos_voice_concierge.fuzzy_matcher import FuzzyMatcher
@@ -48,4 +47,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/voice-engine/src/pos_voice_concierge/whisper_engine.py
+++ b/voice-engine/src/pos_voice_concierge/whisper_engine.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 import io
 import logging
 import os
-from typing import TYPE_CHECKING, Protocol
+import wave
+from typing import TYPE_CHECKING, Any, Protocol
 
 import numpy as np
 
@@ -107,7 +108,8 @@ class WhisperEngine:
             model_name: Whisper モデル名 ("tiny", "base", "small", "medium", "large")
         """
         self._model_name = model_name
-        self._model = None
+        # whisper.load_model が返すモデルオブジェクトは型スタブが無いため Any 扱い
+        self._model: Any = None
 
     def _ensure_model_loaded(self) -> None:
         """モデルがロードされていなければロードする."""
@@ -154,7 +156,7 @@ class WhisperEngine:
                 confidence=avg_confidence,
                 language="ja",
             )
-        except Exception as e:
+        except (wave.Error, EOFError, ValueError, RuntimeError, OSError, MemoryError) as e:
             msg = f"音声認識に失敗しました: {e}"
             raise TranscriptionError(msg) from e
 
@@ -168,8 +170,6 @@ class WhisperEngine:
         Returns:
             float32 の numpy 配列 (-1.0 ~ 1.0)
         """
-        import wave  # noqa: PLC0415
-
         buffer = io.BytesIO(wav_data)
         with wave.open(buffer, "rb") as wf:
             frames = wf.readframes(wf.getnframes())

--- a/voice-engine/tests/test_grpc_server.py
+++ b/voice-engine/tests/test_grpc_server.py
@@ -7,11 +7,11 @@ from unittest.mock import MagicMock
 
 import numpy as np
 
-from pos_voice_concierge.audio_converter import create_wav_from_pcm
+from pos_voice_concierge.audio_converter import AudioConversionError, create_wav_from_pcm
 from pos_voice_concierge.fuzzy_matcher import FuzzyMatcher
 from pos_voice_concierge.generated import voice_service_pb2
 from pos_voice_concierge.grpc_server import VoiceServiceServicer
-from pos_voice_concierge.whisper_engine import TranscriptionResult
+from pos_voice_concierge.whisper_engine import TranscriptionError, TranscriptionResult
 
 
 class MockTranscriptionEngine:
@@ -114,6 +114,90 @@ class TestVoiceServiceServicer:
 
         assert result.transcript == ""
         assert len(result.matches) == 0
+
+
+class FailingTranscriptionEngine:
+    """常に TranscriptionError を送出するモックエンジン."""
+
+    def transcribe(self, audio_data: bytes) -> TranscriptionResult:
+        msg = "model inference failed"
+        raise TranscriptionError(msg)
+
+    def is_loaded(self) -> bool:
+        return True
+
+
+class TestStreamRecognizeErrorPaths:
+    """StreamRecognize / Recognize のエラーパス（#32）."""
+
+    def setup_method(self) -> None:
+        self.matcher = FuzzyMatcher(threshold=70.0)
+        self.matcher.register_product("P001", "コカ・コーラ 500ml")
+        self.context = MagicMock()
+
+    def test_whisper_error_stream_yields_empty_final(self) -> None:
+        """Whisper がエラーでも空の最終結果を返しストリームを完結する."""
+        servicer = VoiceServiceServicer(FailingTranscriptionEngine(), self.matcher)
+        wav_data = _create_test_wav()
+        chunk = voice_service_pb2.AudioChunk(data=wav_data, format="wav", sample_rate=16000)
+
+        results = list(servicer.StreamRecognize(iter([chunk]), self.context))
+
+        assert len(results) >= 1
+        assert results[-1].is_final is True
+        assert results[-1].transcript == ""
+        assert len(results[-1].matches) == 0
+
+    def test_whisper_error_recognize_returns_empty(self) -> None:
+        """単発 Recognize も Whisper エラー時は空結果でフォールバックする."""
+        servicer = VoiceServiceServicer(FailingTranscriptionEngine(), self.matcher)
+        wav_data = _create_test_wav()
+        request = voice_service_pb2.AudioData(data=wav_data, format="wav", sample_rate=16000)
+
+        result = servicer.Recognize(request, self.context)
+
+        assert result.transcript == ""
+        assert result.is_final is True
+        assert len(result.matches) == 0
+
+    def test_audio_conversion_error_stream_yields_empty_final(self, monkeypatch) -> None:
+        """無効な音声フォーマット（変換失敗）でも空の最終結果を返す."""
+
+        def _raise_conversion_error(*_args: object, **_kwargs: object) -> bytes:
+            msg = "unsupported audio format"
+            raise AudioConversionError(msg)
+
+        monkeypatch.setattr(
+            "pos_voice_concierge.grpc_server.convert_to_wav",
+            _raise_conversion_error,
+        )
+        servicer = VoiceServiceServicer(MockTranscriptionEngine(), self.matcher)
+        chunk = voice_service_pb2.AudioChunk(data=b"\x00\x01\x02\x03", format="webm", sample_rate=16000)
+
+        results = list(servicer.StreamRecognize(iter([chunk]), self.context))
+
+        assert len(results) == 1
+        assert results[-1].is_final is True
+        assert results[-1].transcript == ""
+
+    def test_audio_conversion_error_recognize_returns_empty(self, monkeypatch) -> None:
+        """単発 Recognize も変換失敗時は空結果でフォールバックする."""
+
+        def _raise_conversion_error(*_args: object, **_kwargs: object) -> bytes:
+            msg = "unsupported audio format"
+            raise AudioConversionError(msg)
+
+        monkeypatch.setattr(
+            "pos_voice_concierge.grpc_server.convert_to_wav",
+            _raise_conversion_error,
+        )
+        servicer = VoiceServiceServicer(MockTranscriptionEngine(), self.matcher)
+        request = voice_service_pb2.AudioData(data=b"\x00\x01\x02\x03", format="webm", sample_rate=16000)
+
+        result = servicer.Recognize(request, self.context)
+
+        assert result.transcript == ""
+        assert result.is_final is True
 
 
 def _create_test_wav(

--- a/voice-engine/tests/test_query_service.py
+++ b/voice-engine/tests/test_query_service.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 from zoneinfo import ZoneInfo
 
 import grpc  # noqa: TC002
+import psycopg
 import pytest
 
 from pos_voice_concierge.fuzzy_matcher import FuzzyMatcher
@@ -201,7 +202,7 @@ class TestExecuteQueryWithRepository:
     ):
         # インテント分類器が「今日」を商品名としても抽出するため、
         # product_sales_between のエラーハンドリングをテスト
-        mock_repository.product_sales_between.side_effect = RuntimeError("DB connection lost")
+        mock_repository.product_sales_between.side_effect = psycopg.OperationalError("DB connection lost")
         request = query_service_pb2.QueryRequest(text="今日の売上は？")
         response = servicer_with_repo.ExecuteQuery(request, context)
         assert response.intent == "sales_inquiry"
@@ -213,7 +214,7 @@ class TestExecuteQueryWithRepository:
         context,
         mock_repository,
     ):
-        mock_repository.find_stock_by_product_name.side_effect = RuntimeError("DB error")
+        mock_repository.find_stock_by_product_name.side_effect = psycopg.OperationalError("DB error")
         request = query_service_pb2.QueryRequest(text="コカコーラの在庫は？")
         response = servicer_with_repo.ExecuteQuery(request, context)
         assert response.intent == "inventory_inquiry"
@@ -225,7 +226,7 @@ class TestExecuteQueryWithRepository:
         context,
         mock_repository,
     ):
-        mock_repository.top_products_between.side_effect = RuntimeError("DB error")
+        mock_repository.top_products_between.side_effect = psycopg.OperationalError("DB error")
         request = query_service_pb2.QueryRequest(text="売上トップ5を教えて")
         response = servicer_with_repo.ExecuteQuery(request, context)
         assert response.intent == "top_products"


### PR DESCRIPTION
## 概要
品質・テスト・ドキュメントの4件を対応。

fixes #33, fixes #35, fixes #32, fixes #30

## 変更内容

### #33 voice-engine の except Exception 残存
- 売上/在庫/トップ商品の DB 取得を `except psycopg.Error` に絞り込み（予期しないエラーの握り潰しを防止）。
- `WhisperEngine.transcribe` を `except (wave.Error, EOFError, ValueError, RuntimeError, OSError, MemoryError)` に具体化。
- DB エラーを模擬する既存テストを `RuntimeError` → `psycopg.OperationalError` に更新。

### #35 Python type hints 不足 / mypy 型チェック
- `mypy` を導入し `[tool.mypy]` を設定（`disallow_untyped_defs` 等）。CI の Voice Engine ジョブに型チェックステップを追加。
- DB 境界（psycopg カーソルの `object` 値）を `_as_int` / `_as_datetime` 変換ヘルパーで型安全化し、誤った `# type: ignore` を除去。
- `WhisperEngine._model` の型注釈、`server_main` の `sys.exit(main())`（None 返却）を修正。`mypy` は 11 ファイルでエラーゼロ。

### #32 WebSocket/StreamRecognize エラーパス未テスト
- `StreamRecognize` / `Recognize` のエラーパステストを追加: Whisper 認識エラー時の空結果フォールバック、無効な音声フォーマット（変換失敗）時のフォールバック。

### #30 gRPC insecure port の ADR 未記録
- insecure port 使用の設計判断・リスク（内部 MITM）・本番移行計画（mTLS 化）を **ADR-0004** に記録。

## テスト
- voice-engine: 193 テスト pass、`ruff check` pass、`mypy` エラーゼロ
- backend/frontend: 本 PR では未変更（CI で回帰確認）